### PR TITLE
Fix ITKv4 missing header.

### DIFF
--- a/Applications/CLI/DiffusionTensorEstimation/DiffusionTensorEstimation.cxx
+++ b/Applications/CLI/DiffusionTensorEstimation/DiffusionTensorEstimation.cxx
@@ -18,6 +18,7 @@
 #include "vtkITKNewOtsuThresholdImageFilter.h"
 
 #if ITK_VERSION_MAJOR >= 4
+#include "itkFloatingPointExceptions.h"
 #endif
 
 #include "DiffusionTensorEstimationCLP.h"

--- a/Applications/CLI/DiffusionWeightedMasking/DiffusionWeightedMasking.cxx
+++ b/Applications/CLI/DiffusionWeightedMasking/DiffusionWeightedMasking.cxx
@@ -19,6 +19,7 @@
 #include "vtkITKNewOtsuThresholdImageFilter.h"
 
 #if ITK_VERSION_MAJOR >= 4
+#include "itkFloatingPointExceptions.h"
 #endif
 
 #include "DiffusionWeightedMaskingCLP.h"


### PR DESCRIPTION
A header file was missing in two files when ITKv4 is compiled.
