### PR TITLE
ENH: Fix building with cmake version 2.8.9

### DIFF
--- a/SuperBuild/External_BRAINSTools.cmake
+++ b/SuperBuild/External_BRAINSTools.cmake
@@ -33,7 +33,7 @@ endif()
   ExternalProject_Add(${proj}
     GIT_REPOSITORY "${git_protocol}://github.com/BRAINSia/BRAINSStandAlone.git"
     GIT_TAG "${GIT_TAG}"
-    "${slicer_external_update}"
+    ${slicer_external_update}
     SOURCE_DIR ${proj}
     BINARY_DIR ${proj}-build
     CMAKE_GENERATOR ${gen}

--- a/SuperBuild/External_BatchMake.cmake
+++ b/SuperBuild/External_BatchMake.cmake
@@ -30,7 +30,7 @@ endif()
 ExternalProject_Add(${proj}
   GIT_REPOSITORY "${git_protocol}://batchmake.org/BatchMake.git"
   GIT_TAG "1f5bf4f92e8678c34dc6f7558be5e6613804d988"
-  "${slicer_external_update}"
+  ${slicer_external_update}
   SOURCE_DIR BatchMake
   BINARY_DIR BatchMake-build
   CMAKE_GENERATOR ${gen}

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -67,7 +67,7 @@ if(NOT DEFINED CTK_DIR)
   ExternalProject_Add(${proj}
     GIT_REPOSITORY "${git_protocol}://github.com/commontk/CTK.git"
     GIT_TAG "eacf36d3fd547bb67e7b212c46107e220eb2f6a9"
-    "${slicer_external_update}"
+    ${slicer_external_update}
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_GENERATOR ${gen}

--- a/SuperBuild/External_CTKAPPLAUNCHER.cmake
+++ b/SuperBuild/External_CTKAPPLAUNCHER.cmake
@@ -30,7 +30,7 @@ if(Slicer_USE_CTKAPPLAUNCHER)
     ExternalProject_Add(${proj}
       URL http://cloud.github.com/downloads/commontk/AppLauncher/CTKAppLauncher-${launcher_version}-${CTKAPPLAUNCHER_OS}-${CTKAPPLAUNCHER_ARCHITECTURE}.tar.gz
       SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
-      "${slicer_external_update}"
+      ${slicer_external_update}
       CONFIGURE_COMMAND ""
       BUILD_COMMAND ""
       INSTALL_COMMAND ""

--- a/SuperBuild/External_ChangeTrackerPy.cmake
+++ b/SuperBuild/External_ChangeTrackerPy.cmake
@@ -28,7 +28,7 @@ if(NOT DEFINED ChangeTrackerPy_SOURCE_DIR)
   ExternalProject_Add(${proj}
     GIT_REPOSITORY "${git_protocol}://github.com/fedorov/ChangeTrackerPy.git"
     GIT_TAG "68b70e15ada3b46742ab3374a62e3eb02a5d101a"
-    "${slicer_external_update}"
+    ${slicer_external_update}
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_GENERATOR ${gen}

--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -32,7 +32,7 @@ if(NOT DEFINED DCMTK_DIR)
     SOURCE_DIR ${proj}
     BINARY_DIR ${proj}-build
     INSTALL_DIR ${proj}-install
-    "${slicer_external_update}"
+    ${slicer_external_update}
     CMAKE_GENERATOR ${gen}
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>

--- a/SuperBuild/External_EMSegment.cmake
+++ b/SuperBuild/External_EMSegment.cmake
@@ -23,7 +23,7 @@ if(NOT DEFINED EMSegment_SOURCE_DIR)
   ExternalProject_Add(${proj}
     SVN_REPOSITORY "http://svn.slicer.org/Slicer3/trunk/Modules/EMSegment"
     SVN_REVISION -r "17011"
-    "${slicer_external_update}"
+    ${slicer_external_update}
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_GENERATOR ${gen}

--- a/SuperBuild/External_ITKv3.cmake
+++ b/SuperBuild/External_ITKv3.cmake
@@ -42,7 +42,7 @@ if(NOT DEFINED ITK_DIR)
   ExternalProject_Add(${proj}
     GIT_REPOSITORY "${git_protocol}://${${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY}"
     GIT_TAG ${${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG}
-    "${slicer_external_update}"
+    ${slicer_external_update}
     SOURCE_DIR ${proj}
     BINARY_DIR ${proj}-build
     CMAKE_GENERATOR ${gen}

--- a/SuperBuild/External_ITKv4.cmake
+++ b/SuperBuild/External_ITKv4.cmake
@@ -78,7 +78,7 @@ if(NOT DEFINED ITK_DIR)
   ExternalProject_Add(${proj}
     GIT_REPOSITORY ${ITKv4_REPOSITORY}
     GIT_TAG ${ITKv4_GIT_TAG}
-    "${slicer_external_update}"
+    ${slicer_external_update}
     SOURCE_DIR ${proj}
     BINARY_DIR ${proj}-build
     CMAKE_GENERATOR ${gen}

--- a/SuperBuild/External_LibArchive.cmake
+++ b/SuperBuild/External_LibArchive.cmake
@@ -62,7 +62,7 @@ if(NOT DEFINED LibArchive_DIR)
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     INSTALL_DIR LibArchive-install
-    "${slicer_external_update}"
+    ${slicer_external_update}
     CMAKE_GENERATOR ${gen}
     CMAKE_ARGS
     # Not used -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}

--- a/SuperBuild/External_MultiVolumeExplorer.cmake
+++ b/SuperBuild/External_MultiVolumeExplorer.cmake
@@ -28,7 +28,7 @@ if(NOT DEFINED MultiVolumeExplorer_SOURCE_DIR)
   ExternalProject_Add(${proj}
     GIT_REPOSITORY "${git_protocol}://github.com/fedorov/MultiVolumeExplorer.git"
     GIT_TAG "bdb0af5cd7ef3609d04736af15fe6281c032fd25"
-    "${slicer_external_update}"
+    ${slicer_external_update}
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_GENERATOR ${gen}

--- a/SuperBuild/External_MultiVolumeImporter.cmake
+++ b/SuperBuild/External_MultiVolumeImporter.cmake
@@ -28,7 +28,7 @@ if(NOT DEFINED MultiVolumeImporter_SOURCE_DIR)
   ExternalProject_Add(${proj}
     GIT_REPOSITORY "${git_protocol}://github.com/fedorov/MultiVolumeImporter.git"
     GIT_TAG "2a2c65d11b4a1d65be00e91e41acec1a200aab06"
-    "${slicer_external_update}"
+    ${slicer_external_update}
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_GENERATOR ${gen}

--- a/SuperBuild/External_NUMPY.cmake
+++ b/SuperBuild/External_NUMPY.cmake
@@ -46,7 +46,7 @@ ExternalProject_Add(${proj}
   DOWNLOAD_DIR ${CMAKE_CURRENT_BINARY_DIR}
   SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/NUMPY
   BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/NUMPY
-  "${slicer_external_update}"
+  ${slicer_external_update}
   CONFIGURE_COMMAND ${CMAKE_COMMAND}
     -P ${CMAKE_CURRENT_BINARY_DIR}/${proj}_configure_step.cmake
   BUILD_COMMAND ${CMAKE_COMMAND}

--- a/SuperBuild/External_OpenIGTLink.cmake
+++ b/SuperBuild/External_OpenIGTLink.cmake
@@ -27,7 +27,7 @@ endif()
 ExternalProject_Add(${proj}
   SVN_REPOSITORY "http://svn.na-mic.org/NAMICSandBox/trunk/OpenIGTLink"
   SVN_REVISION -r "7701"
-  "${slicer_external_update}"
+  ${slicer_external_update}
   SOURCE_DIR OpenIGTLink
   BINARY_DIR OpenIGTLink-build
   CMAKE_GENERATOR ${gen}

--- a/SuperBuild/External_OpenIGTLinkIF.cmake
+++ b/SuperBuild/External_OpenIGTLinkIF.cmake
@@ -23,7 +23,7 @@ if(NOT DEFINED OpenIGTLinkIF_SOURCE_DIR)
   ExternalProject_Add(${proj}
     SVN_REPOSITORY "http://svn.na-mic.org/NAMICSandBox/trunk/IGTLoadableModules/QtModules/OpenIGTLinkIF/"
     SVN_REVISION -r "7909"
-    "${slicer_external_update}"
+    ${slicer_external_update}
     #GIT_REPOSITORY "${git_protocol}://github.com/Slicer/OpenIGTLinkIF.git"
     #GIT_TAG "8330b769cc8c607067134296d577b64ae7c92b87"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}

--- a/SuperBuild/External_PCRE.cmake
+++ b/SuperBuild/External_PCRE.cmake
@@ -35,6 +35,6 @@ set(pcre_CONFIGURE_COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/pcre_
 ExternalProject_add(PCRE
   URL http://downloads.sourceforge.net/project/pcre/pcre/8.12/pcre-8.12.tar.gz
   URL_MD5 fa69e4c5d8971544acd71d1f10d59193
-  "${slicer_external_update}"
+  ${slicer_external_update}
   CONFIGURE_COMMAND ${pcre_CONFIGURE_COMMAND}
   )

--- a/SuperBuild/External_SciPy.cmake
+++ b/SuperBuild/External_SciPy.cmake
@@ -17,7 +17,7 @@ set(proj SciPy)
 
 ExternalProject_Add(${proj}
   SVN_REPOSITORY "http://svn.scipy.org/svn/scipy/branches/0.7.x"
-  "${slicer_external_update}"
+  ${slicer_external_update}
   SOURCE_DIR python/scipy
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""

--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -50,7 +50,7 @@ ExternalProject_add(SimpleITK
   GIT_REPOSITORY http://itk.org/SimpleITK.git
   # This is the tag for the "master" branch as of June 8th, 2012
   GIT_TAG 9465b2d518ce39db24d770cff4095c27f6556249 # 2012-07-23
-  "${slicer_external_update}"
+  ${slicer_external_update}
   CMAKE_ARGS
     -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
     -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}

--- a/SuperBuild/External_SlicerExecutionModel.cmake
+++ b/SuperBuild/External_SlicerExecutionModel.cmake
@@ -37,7 +37,7 @@ if(NOT DEFINED SlicerExecutionModel_DIR)
   ExternalProject_Add(${proj}
     GIT_REPOSITORY "${git_protocol}://github.com/Slicer/SlicerExecutionModel.git"
     GIT_TAG "b6125d3f5f29f7395fee060a0a0bb04409818ad4"
-    "${slicer_external_update}"
+    ${slicer_external_update}
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_GENERATOR ${gen}

--- a/SuperBuild/External_SlicerWebGLExport.cmake
+++ b/SuperBuild/External_SlicerWebGLExport.cmake
@@ -28,7 +28,7 @@ if(NOT DEFINED SlicerWebGLExport_SOURCE_DIR)
   ExternalProject_Add(${proj}
     GIT_REPOSITORY "${git_protocol}://github.com/xtk/SlicerWebGLExport.git"
     GIT_TAG "be54b2a30017971f938a9c2878db948fb3608cd9"
-    "${slicer_external_update}"
+    ${slicer_external_update}
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_GENERATOR ${gen}

--- a/SuperBuild/External_Swig.cmake
+++ b/SuperBuild/External_Swig.cmake
@@ -19,7 +19,7 @@ if(NOT SWIG_DIR)
       URL http://prdownloads.sourceforge.net/swig/swigwin-${TARGET_SWIG_VERSION}.zip
       URL_MD5 4ab8064b1a8894c8577ef9d0fb2523c8
       SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/swigwin-${TARGET_SWIG_VERSION}
-      "${slicer_external_update}"
+      ${slicer_external_update}
       CONFIGURE_COMMAND ""
       BUILD_COMMAND ""
       INSTALL_COMMAND ""

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -140,7 +140,7 @@ if(NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR)
     BINARY_DIR ${proj}-build
     GIT_REPOSITORY "${git_protocol}://${${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY}"
     GIT_TAG ${${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG}
-    "${slicer_external_update}"
+    ${slicer_external_update}
     CMAKE_GENERATOR ${gen}
     ${CUSTOM_BUILD_COMMAND}
     CMAKE_ARGS

--- a/SuperBuild/External_cmcurl.cmake
+++ b/SuperBuild/External_cmcurl.cmake
@@ -26,7 +26,7 @@ endif()
 ExternalProject_Add(${proj}
   SVN_REPOSITORY "http://svn.slicer.org/Slicer3-lib-mirrors/trunk/cmcurl"
   SVN_REVISION -r "138"
-  "${slicer_external_update}"
+  ${slicer_external_update}
   SOURCE_DIR cmcurl
   BINARY_DIR cmcurl-build
   CMAKE_GENERATOR ${gen}

--- a/SuperBuild/External_incrTcl.cmake
+++ b/SuperBuild/External_incrTcl.cmake
@@ -57,7 +57,7 @@ if(NOT WIN32)
   ExternalProject_Add(${proj}
     SVN_REPOSITORY ${incrTcl_SVN_REPOSITORY}
     SVN_REVISION ${incrTcl_SVN_REVISION}
-    "${slicer_external_update}"
+    ${slicer_external_update}
     SOURCE_DIR tcl/incrTcl
     BUILD_IN_SOURCE ${incrTcl_BUILD_IN_SOURCE}
     PATCH_COMMAND ${incrTcl_PATCH_COMMAND}

--- a/SuperBuild/External_jqPlot.cmake
+++ b/SuperBuild/External_jqPlot.cmake
@@ -19,7 +19,7 @@ if(NOT DEFINED jqPlot_DIR)
   ExternalProject_Add(${proj}
     URL http://cloud.github.com/downloads/Slicer/jqPlot/jquery.jqplot.1.0.0b2_r1012.tar.gz
     URL_MD5 2afa87db609446d568b79a9ae5c07523
-    "${slicer_external_update}"
+    ${slicer_external_update}
     SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/jqPlot
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/jqPlot-build
     CONFIGURE_COMMAND ""

--- a/SuperBuild/External_python_unix.cmake
+++ b/SuperBuild/External_python_unix.cmake
@@ -48,7 +48,7 @@ set(python_INSTALL_COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/pytho
 ExternalProject_Add(${proj}
   URL ${python_URL}
   URL_MD5 ${python_MD5}
-  "${slicer_external_update}"
+  ${slicer_external_update}
   DOWNLOAD_DIR ${CMAKE_CURRENT_BINARY_DIR}
   SOURCE_DIR ${python_SOURCE_DIR}
   BUILD_IN_SOURCE ${python_BUILD_IN_SOURCE}

--- a/SuperBuild/External_python_win.cmake
+++ b/SuperBuild/External_python_win.cmake
@@ -85,7 +85,7 @@ set_ep_build_command_args(select)
 ExternalProject_Add(${proj}
   URL ${python_URL}
   URL_MD5 ${python_MD5}
-  "${slicer_external_update}"
+  ${slicer_external_update}
   DOWNLOAD_DIR ${CMAKE_CURRENT_BINARY_DIR}
   SOURCE_DIR python-build
   PATCH_COMMAND ${python_PATCH_COMMAND}

--- a/SuperBuild/External_qCDashAPI.cmake
+++ b/SuperBuild/External_qCDashAPI.cmake
@@ -37,7 +37,7 @@ if(NOT DEFINED qCDashAPI_DIR)
   ExternalProject_Add(${proj}
     GIT_REPOSITORY "${git_protocol}://github.com/jcfr/qCDashAPI.git"
     GIT_TAG "9cd19663c1884b28ba4ad4153b290bf9da5500ab"
-    "${slicer_external_update}"
+    ${slicer_external_update}
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_GENERATOR ${gen}

--- a/SuperBuild/External_qMidasAPI.cmake
+++ b/SuperBuild/External_qMidasAPI.cmake
@@ -37,7 +37,7 @@ if(NOT DEFINED qMidasAPI_DIR)
   ExternalProject_Add(${proj}
     GIT_REPOSITORY "${git_protocol}://github.com/Slicer/qMidasAPI.git"
     GIT_TAG "3a92ef0edb6a40005169fe3bc6b6f9123f0b03bc"
-    "${slicer_external_update}"
+    ${slicer_external_update}
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_GENERATOR ${gen}

--- a/SuperBuild/External_tcl.cmake
+++ b/SuperBuild/External_tcl.cmake
@@ -78,7 +78,7 @@ endif()
 ExternalProject_Add(${proj}
   SVN_REPOSITORY ${tcl_SVN_REPOSITORY}
   SVN_REVISION ${tcl_SVN_REVISION}
-  "${slicer_external_update}"
+  ${slicer_external_update}
   SOURCE_DIR ${tcl_SOURCE_DIR}
   BUILD_IN_SOURCE ${tcl_BUILD_IN_SOURCE}
   CONFIGURE_COMMAND ${tcl_CONFIGURE_COMMAND}

--- a/SuperBuild/External_teem.cmake
+++ b/SuperBuild/External_teem.cmake
@@ -44,7 +44,7 @@ ExternalProject_Add(${proj}
   DOWNLOAD_DIR ${CMAKE_CURRENT_BINARY_DIR}
   SOURCE_DIR teem
   BINARY_DIR teem-build
-  "${slicer_external_update}"
+  ${slicer_external_update}
   CMAKE_GENERATOR ${gen}
   CMAKE_ARGS
       -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}

--- a/SuperBuild/External_tk.cmake
+++ b/SuperBuild/External_tk.cmake
@@ -57,7 +57,7 @@ if(NOT WIN32)
   ExternalProject_Add(${proj}
     SVN_REPOSITORY ${tk_SVN_REPOSITORY}
     SVN_REVISION ${tk_SVN_REVISION}
-    "${slicer_external_update}"
+    ${slicer_external_update}
     SOURCE_DIR ${tk_SOURCE_DIR}
     BUILD_IN_SOURCE ${tk_BUILD_IN_SOURCE}
     CONFIGURE_COMMAND ${tk_CONFIGURE_COMMAND}

--- a/SuperBuild/External_weave.cmake
+++ b/SuperBuild/External_weave.cmake
@@ -36,7 +36,7 @@ ExternalProject_Add(weave
   # URL ${Slicer_SOURCE_DIR}/Modules/Python/FilteredTractography/weave
   SVN_REPOSITORY http://svn.slicer.org/Slicer3-lib-mirrors/trunk/weave
   SVN_REVISION -r "154"
-  "${slicer_external_update}"
+  ${slicer_external_update}
   BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/weave
   SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/weave
   BUILD_COMMAND ${CMAKE_COMMAND}

--- a/SuperBuild/External_zlib.cmake
+++ b/SuperBuild/External_zlib.cmake
@@ -38,7 +38,7 @@ if(NOT DEFINED zlib_DIR)
   ExternalProject_Add(${proj}
     GIT_REPOSITORY "${git_protocol}://github.com/commontk/zlib.git"
     GIT_TAG "66a753054b356da85e1838a081aa94287226823e"
-    "${slicer_external_update}"
+    ${slicer_external_update}
     SOURCE_DIR zlib
     BINARY_DIR zlib-build
     INSTALL_DIR zlib-install


### PR DESCRIPTION
The format caused a nesting and list with the extra quotes
that resulted in a parsing error where an extraneous ';'

-- verifying file...
     file='Slicer-git-itkv4/CTKAPPLAUNCHER-prefix/src/CTKAppLauncher-0.1.7-macosx-amd64.tar.gz'
-- verifying file... warning: did not verify file - no URL_MD5 checksum argument? corrupt file?
-- extracting...
     src='Slicer-git-itkv4/CTKAPPLAUNCHER-prefix/src/CTKAppLauncher-0.1.7-macosx-amd64.tar.gz'
     dst='Slicer-git-itkv4/CTKAPPLAUNCHER;'
-- extracting... [tar xfz]
CMake Error at CTKAPPLAUNCHER-prefix/src/CTKAPPLAUNCHER-stamp/extract-CTKAPPLAUNCHER.cmake:26 (execute_process):
  execute_process given unknown argument /../ex-CTKAPPLAUNCHER1239.

make[2]: **\* [CTKAPPLAUNCHER-prefix/src/CTKAPPLAUNCHER-stamp/CTKAPPLAUNCHER-download] Error 1
make[1]: **\* [CMakeFiles/CTKAPPLAUNCHER.dir/all] Error 2
make: **\* [all] Error 2
