### PR TITLE
COMP: Add DWIConvert as a CLI Module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,9 @@ CMAKE_DEPENDENT_OPTION(
   "Slicer_BUILD_QTSCRIPTEDMODULES" OFF)
 mark_as_advanced(Slicer_BUILD_SlicerWebGLExport)
 
+CMAKE_DEPENDENT_OPTION(Slicer_BUILD_DWIConvert "Build DWIConvert." ON
+  "Slicer_BUILD_DICOM_SUPPORT" OFF)
+
 #-----------------------------------------------------------------------------
 # Install no development files by default, but allow the user to get
 # them installed by setting Slicer_INSTALL_DEVELOPMENT to true.

--- a/Modules/CLI/CMakeLists.txt
+++ b/Modules/CLI/CMakeLists.txt
@@ -170,3 +170,8 @@ if(Slicer_BUILD_BRAINSTOOLS)
     )
 endif()
 
+if(Slicer_BUILD_DWIConvert)
+  message("DCMTK_DIR = ${DCMTK_DIR}")
+  add_subdirectory(${DWIConvert_SOURCE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}/DWIConvert)
+endif()

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -137,6 +137,10 @@ if(Slicer_BUILD_SlicerWebGLExport)
   list(APPEND Slicer_DEPENDENCIES SlicerWebGLExport)
 endif()
 
+if(Slicer_BUILD_DWIConvert)
+  list(APPEND Slicer_DEPENDENCIES DWIConvert)
+endif()
+
 SlicerMacroCheckExternalProjectDependency(Slicer)
 
 #-----------------------------------------------------------------------------
@@ -311,11 +315,17 @@ if(APPLE)
     -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
 endif()
 
+if(Slicer_BUILD_DWIConvert)
+  list(APPEND ep_superbuild_extra_args
+    -DDWIConvert_SOURCE_DIR:PATH=${DWIConvert_SOURCE_DIR}
+    )
+endif()
+
 #------------------------------------------------------------------------------
 # Configure and build Slicer
 #------------------------------------------------------------------------------
 set(proj Slicer)
-
+message("DCMTK_DIR=${DCMTK_DIR}")
 ExternalProject_Add(${proj}
   DEPENDS ${Slicer_DEPENDENCIES}
   DOWNLOAD_COMMAND ""
@@ -360,6 +370,8 @@ ExternalProject_Add(${proj}
     # Qt
     -DSlicer_REQUIRED_QT_VERSION:STRING=${Slicer_REQUIRED_QT_VERSION}
     -DQT_QMAKE_EXECUTABLE:PATH=${QT_QMAKE_EXECUTABLE}
+    # DCMTK
+    -DDCMTK_DIR:PATH=${DCMTK_DIR}
     # CTK
     -DCTK_DIR:PATH=${CTK_DIR}
     # jqPlot

--- a/SuperBuild/DWIConvert.CMakeLists.txt
+++ b/SuperBuild/DWIConvert.CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(DWIConvert)

--- a/SuperBuild/External_DWIConvert.cmake
+++ b/SuperBuild/External_DWIConvert.cmake
@@ -1,0 +1,47 @@
+
+set(DWIConvert_DEPENDENCIES ITKv4 DCMTK SlicerExecutionModel)
+
+SlicerMacroCheckExternalProjectDependency(DWIConvert)
+
+set(proj DWIConvert)
+
+set(DWIConvert_REPOSITORY
+  ${git_protocol}://github.com/Chaircrusher/NewDicomToNrrdConverter.git)
+
+set(DWIConvert_GIT_TAG 16208d48ef36d5a308eb776efc8e5868a9b18054 )
+set(DWIConvert_DCMTK_ARGS -DDCMTK_DIR:PATH=${DCMTK_DIR} )
+
+ExternalProject_Add(${proj}
+  GIT_REPOSITORY ${DWIConvert_REPOSITORY}
+  GIT_TAG ${DWIConvert_GIT_TAG}
+  ${slicer_external_update}
+  SOURCE_DIR ${proj}
+  BINARY_DIR ${proj}-build
+  CMAKE_GENERATOR ${gen}
+  CMAKE_ARGS
+  -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+  -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
+  -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+  -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
+  -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+  -DBUILD_SHARED_LIBS:BOOL=ON
+  -DUSE_SYSTEM_DCMTK:BOOL=${Slicer_BUILD_DICOM_SUPPORT}
+  -DITK_DIR=${ITK_DIR}
+  ${DWIConvert_DCMTK_ARGS}
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+  DEPENDS
+  ${DWIConvert_DEPENDENCIES}
+  )
+
+ExternalProject_Add_Step(${proj} InstallSlicerCMakeLists
+  COMMENT "Install simple CMakeList.txt for DWIConvert"
+  DEPENDEES download
+  DEPENDERS configure
+  COMMAND ${CMAKE_COMMAND}
+  -E copy ${CMAKE_CURRENT_LIST_DIR}/DWIConvert.CMakeLists.txt
+  <SOURCE_DIR>/CMakeLists.txt
+  )
+
+set(DWIConvert_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})


### PR DESCRIPTION
DWIConvert is a compatible replacement for DicomToNrrdConverter.  This patch uses CMake's ExternalProject to download the source code from 

https://github.com/Chaircrusher/NewDicomToNrrdConverter

and build it as part of the Modules/CLI build.
