### PR TITLE
BUG: Fix spacing buttons in slice controller widget

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSliceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.h
@@ -326,8 +326,9 @@ class VTK_MRML_EXPORT vtkMRMLSliceNode : public vtkMRMLAbstractViewNode
     MultiplanarReformatFlag = 16, // broadcast reformat widget transformation
     XYZOriginFlag = 32,
     LabelOutlineFlag = 64,
-    SliceVisibleFlag = 128
-    // Next one needs to be 256
+    SliceVisibleFlag = 128,
+    SliceSpacingFlag = 256
+    // Next one needs to be 512
   };
 
   /// Get/Set a flag indicating what parameters are being manipulated

--- a/Libs/MRML/Logic/vtkMRMLSliceLinkLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLinkLogic.cxx
@@ -451,8 +451,15 @@ void vtkMRMLSliceLinkLogic::BroadcastSliceNodeEvent(vtkMRMLSliceNode *sliceNode)
             }
           }        
 
+          // Setting the slice spacing
+          if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
+            & vtkMRMLSliceNode::SliceSpacingFlag)
+            {
+            sNode->SetSliceSpacingMode( sliceNode->GetSliceSpacingMode() );
+            sNode->SetPrescribedSliceSpacing( sliceNode->GetPrescribedSliceSpacing() );
+            }
         //
-        // End of the block for broadcasting parametes and command
+        // End of the block for broadcasting parameters and commands
         // that do not require the orientation to match
         //
         }

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLSliceControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLSliceControllerWidget.ui
@@ -183,6 +183,9 @@
           <property name="text">
            <string/>
           </property>
+          <property name="toolTip">
+           <string>Slice spacing may be set automatically or manually by the user or context</string>
+          </property>
           <property name="icon">
            <iconset resource="../qMRMLWidgets.qrc">
             <normaloff>:/Icons/SlicerAutomaticSliceSpacing.png</normaloff>:/Icons/SlicerAutomaticSliceSpacing.png</iconset>
@@ -662,7 +665,8 @@
    </property>
    <property name="icon">
     <iconset resource="../qMRMLWidgets.qrc">
-     <normaloff>:/Icons/SlicerManualSliceSpacing.png</normaloff>:/Icons/SlicerManualSliceSpacing.png</iconset>
+     <normaloff>:/Icons/SlicerManualSliceSpacing.png</normaloff>
+     <normalon>:/Icons/SlicerAutomaticSliceSpacing.png</normalon>:/Icons/SlicerAutomaticSliceSpacing.png</iconset>
    </property>
    <property name="text">
     <string>Automatic</string>

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLSliceInformationWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLSliceInformationWidget.ui
@@ -208,7 +208,7 @@
    <item row="8" column="0">
     <widget class="QLabel" name="label_9">
      <property name="toolTip">
-      <string>Slice spacing can be prescribed by the user or context or set automatically</string>
+      <string>Slice spacing may be set automatically or manually by the user or context</string>
      </property>
      <property name="text">
       <string>Slice spacing mode:</string>
@@ -233,7 +233,7 @@
      <item>
       <widget class="QRadioButton" name="PrescribedSliceSpacingRadioButton">
        <property name="text">
-        <string>Prescribed</string>
+        <string>Manual</string>
        </property>
       </widget>
      </item>
@@ -242,7 +242,7 @@
    <item row="9" column="0">
     <widget class="QLabel" name="label_10">
      <property name="text">
-      <string>Prescribed spacing:</string>
+      <string>Manual spacing:</string>
      </property>
     </widget>
    </item>
@@ -252,7 +252,7 @@
       <bool>false</bool>
      </property>
      <property name="toolTip">
-      <string>Slice spacing used when slice spacing mode is prescribed by the user or by the context</string>
+      <string>Manual spacing is used when slice spacing is set manually by the user or context</string>
      </property>
      <property name="decimals">
       <number>1</number>
@@ -275,7 +275,7 @@
    <item row="5" column="0">
     <widget class="QLabel" name="label_7">
      <property name="toolTip">
-      <string>Field of view of the slice.</string>
+      <string>Field of view of slice</string>
      </property>
      <property name="text">
       <string>Field of view:</string>

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -790,9 +790,18 @@ void qMRMLSliceControllerWidgetPrivate::updateWidgetFromMRMLSliceNode()
   this->actionShow_reformat_widget->setText(
     showReformat ? tr("Hide reformat widget"): tr("Show reformat widget"));
   // Slice spacing mode
+  this->SliceSpacingButton->setIcon(
+    this->MRMLSliceNode->GetSliceSpacingMode() == vtkMRMLSliceNode::AutomaticSliceSpacingMode ?
+      QIcon(":/Icons/SlicerAutomaticSliceSpacing.png") :
+      QIcon(":/Icons/SlicerManualSliceSpacing.png"));
   this->actionSliceSpacingModeAutomatic->setChecked(
     this->MRMLSliceNode->GetSliceSpacingMode() == vtkMRMLSliceNode::AutomaticSliceSpacingMode);
-  double fov[3];
+  // Prescribed slice spacing
+  double spacing[3] = {0.0, 0.0, 0.0};
+  this->MRMLSliceNode->GetPrescribedSliceSpacing(spacing);
+  this->SliceSpacingSpinBox->setValue(spacing[2]);
+  // Field of view
+  double fov[3]  = {0.0, 0.0, 0.0};
   this->MRMLSliceNode->GetFieldOfView(fov);
   wasBlocked = this->SliceFOVSpinBox->blockSignals(true);
   this->SliceFOVSpinBox->setValue(fov[0] < fov[1] ? fov[0] : fov[1]);
@@ -1901,60 +1910,37 @@ void qMRMLSliceControllerWidget::setCompositingToSubtract()
 void qMRMLSliceControllerWidget::setSliceSpacingMode(bool automatic)
 {
   Q_D(qMRMLSliceControllerWidget);
-  vtkSmartPointer<vtkCollection> nodes = d->saveNodesForUndo("vtkMRMLSliceNode");
-  if (!nodes.GetPointer())
+  if (!d->MRMLSliceNode || !d->MRMLSliceCompositeNode)
     {
     return;
     }
-  vtkMRMLSliceNode* node = 0;
-  vtkCollectionSimpleIterator it;
-  for (nodes->InitTraversal(it);(node = static_cast<vtkMRMLSliceNode*>(
-                                   nodes->GetNextItemAsObject(it)));)
+  d->SliceLogic->StartSliceNodeInteraction(vtkMRMLSliceNode::SliceSpacingFlag);
+  if (automatic)
     {
-    if (node == d->MRMLSliceNode || this->isLinked())
-      {
-      if (automatic)
-        {
-        node->SetSliceSpacingModeToAutomatic();
-        }
-      else
-        {
-        node->SetSliceSpacingModeToPrescribed();
-        }
-      }
+    d->MRMLSliceNode->SetSliceSpacingModeToAutomatic();
     }
+  else
+    {
+    d->MRMLSliceNode->SetSliceSpacingModeToPrescribed();
+    }
+  d->SliceLogic->EndSliceNodeInteraction();
 }
 
 //---------------------------------------------------------------------------
 void qMRMLSliceControllerWidget::setSliceSpacing(double sliceSpacing)
 {
   Q_D(qMRMLSliceControllerWidget);
-  this->setSliceSpacingMode(false);
-  vtkSmartPointer<vtkCollection> nodes = d->saveNodesForUndo("vtkMRMLSliceNode");
-  if (!nodes.GetPointer())
+  if (!d->MRMLSliceNode || !d->MRMLSliceCompositeNode)
     {
     return;
     }
-  vtkMRMLSliceNode* node = 0;
-  vtkCollectionSimpleIterator it;
-  for (nodes->InitTraversal(it);(node = static_cast<vtkMRMLSliceNode*>(
-                                   nodes->GetNextItemAsObject(it)));)
-    {
-    if (node == d->MRMLSliceNode || this->isLinked())
-      {
-      double *current = node->GetPrescribedSliceSpacing();
-      double spacing[3];
-      spacing[0] = current[0];
-      spacing[1] = current[1];
-      spacing[2] = sliceSpacing;
-      node->SetPrescribedSliceSpacing(spacing);
-      vtkMRMLSliceLogic* sliceLogic = d->sliceNodeLogic(node);
-      if (sliceLogic)
-        {
-        sliceLogic->ResizeSliceNode(d->ViewSize.width(), d->ViewSize.height());
-        }
-      }
-    }
+  d->SliceLogic->StartSliceNodeInteraction(vtkMRMLSliceNode::SliceSpacingFlag);
+  d->MRMLSliceNode->SetSliceSpacingModeToPrescribed();
+  double spacing[3] = {0.0, 0.0, 0.0};
+  d->MRMLSliceNode->GetPrescribedSliceSpacing(spacing);
+  spacing[2] = sliceSpacing;
+  d->MRMLSliceNode->SetPrescribedSliceSpacing(spacing);
+  d->SliceLogic->EndSliceNodeInteraction();
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
Ensures automatic spacing button in slice view controller widget toggles automatic spacing on and off, and updates the icon in the widget to reflect the spacing mode. Ensures automatic spacing, manual spacing, and field of view buttons are synchronized with MRML slice nodes. Ensures automatic spacing, manual spacing, and field of view buttons for each of R, Y, G update together appropriately when linked. #2993, in part similar to #2676-2685.
