### PR TITLE
BUG: Fix issue 2992: Crash when MRML nodes registered to a vtkMRMLIGTLCo...

### DIFF
--- a/SuperBuild/External_OpenIGTLinkIF.cmake
+++ b/SuperBuild/External_OpenIGTLinkIF.cmake
@@ -23,7 +23,7 @@ if(NOT DEFINED OpenIGTLinkIF_SOURCE_DIR)
   ExternalProject_Add(${proj}
     "${${PROJECT_NAME}_EP_UPDATE_IF_GREATER_288}"
     GIT_REPOSITORY "${git_protocol}://github.com/openigtlink/OpenIGTLinkIF.git"
-    GIT_TAG "cd3464882eb7f092feb84ca4bfc5162e070db1ad"
+    GIT_TAG "f9b65b1ffd2992862025f3c6ec5fe30e6f5dd395"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_GENERATOR ${gen}


### PR DESCRIPTION
OpenIGTLinkIF module is updated to fix a issue reported in
http://www.na-mic.org/Bug/view.php?id=2992

Junichi
