### PR TITLE
STYLE: ITK_EXPORT had no use

### DIFF
--- a/Libs/vtkITK/itkConstrainedValueMultiplicationImageFilter.h
+++ b/Libs/vtkITK/itkConstrainedValueMultiplicationImageFilter.h
@@ -83,7 +83,7 @@ public:
 }
 
 template <class TInputImage1, class TInputImage2, class TOutputImage>
-class ITK_EXPORT ConstrainedValueMultiplicationImageFilter :
+class ConstrainedValueMultiplicationImageFilter :
     public
 BinaryFunctorImageFilter<TInputImage1,TInputImage2,TOutputImage, 
                          Functor::ConstrainedValueMultiplication< 

--- a/Libs/vtkITK/itkGrowCutSegmentationImageFilter.h
+++ b/Libs/vtkITK/itkGrowCutSegmentationImageFilter.h
@@ -56,7 +56,7 @@ namespace itk
 template<class TInputImage, 
   class TOutputImage, 
   class TWeightPixelType = float> 
-  class ITK_EXPORT GrowCutSegmentationImageFilter: public ImageToImageFilter<TInputImage,TOutputImage> 
+  class GrowCutSegmentationImageFilter: public ImageToImageFilter<TInputImage,TOutputImage> 
 {
 
  public:

--- a/Libs/vtkITK/itkLevelTracingImageFilter.h
+++ b/Libs/vtkITK/itkLevelTracingImageFilter.h
@@ -27,7 +27,7 @@ namespace itk
  */
 
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT LevelTracingImageFilter:public ImageToImageFilter<TInputImage,TOutputImage>
+class LevelTracingImageFilter:public ImageToImageFilter<TInputImage,TOutputImage>
 {
 public:
   /** Standard class typedefs. */

--- a/Libs/vtkITK/itkLevelTracingImageFilter.txx
+++ b/Libs/vtkITK/itkLevelTracingImageFilter.txx
@@ -13,7 +13,7 @@ namespace itk
 {
 
 template <class TInputImage, class TCoordRep = float>
-class ITK_EXPORT LevelTracingImageFunction : 
+class LevelTracingImageFunction : 
     public ImageFunction<TInputImage,bool,TCoordRep> 
 {
 public:

--- a/Libs/vtkITK/itkNewOtsuThresholdImageCalculator.h
+++ b/Libs/vtkITK/itkNewOtsuThresholdImageCalculator.h
@@ -25,7 +25,7 @@ namespace itk
  * \ingroup Operators
  */
 template <class TInputImage>            
-class ITK_EXPORT NewOtsuThresholdImageCalculator : public Object 
+class NewOtsuThresholdImageCalculator : public Object 
 {
 public:
   /** Standard class typedefs. */

--- a/Libs/vtkITK/itkNewOtsuThresholdImageFilter.h
+++ b/Libs/vtkITK/itkNewOtsuThresholdImageFilter.h
@@ -39,7 +39,7 @@ namespace itk
  * \ingroup IntensityImageFilters  Multithreaded
  */
 template<class TInputImage, class TOutputImage>
-class ITK_EXPORT NewOtsuThresholdImageFilter : 
+class NewOtsuThresholdImageFilter : 
     public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/Modules/CLI/DWIJointRicianLMMSEFilter/itkComputeRestrictedHistogram.h
+++ b/Modules/CLI/DWIJointRicianLMMSEFilter/itkComputeRestrictedHistogram.h
@@ -28,7 +28,7 @@ namespace itk
  * \brief Compute mean, std, min, and max of positive pixels
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT ComputeRestrictedHistogram : public ImageToImageFilter<TInputImage, TOutputImage>
+class ComputeRestrictedHistogram : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Convenient typedefs for simplifying declarations. */

--- a/Modules/CLI/DWIJointRicianLMMSEFilter/itkLMMSEVectorImageFilter.h
+++ b/Modules/CLI/DWIJointRicianLMMSEFilter/itkLMMSEVectorImageFilter.h
@@ -39,7 +39,7 @@ bool UNLM_gradientDistance_smaller( OrderType e1, OrderType e2 )
 */
 
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT LMMSEVectorImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
+class LMMSEVectorImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Convenient typedefs for simplifying declarations. */

--- a/Modules/CLI/DWIJointRicianLMMSEFilter/itkOtsuStatistics.h
+++ b/Modules/CLI/DWIJointRicianLMMSEFilter/itkOtsuStatistics.h
@@ -19,7 +19,7 @@ namespace itk
  */
 
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT OtsuStatistics : public ImageToImageFilter<TInputImage, TOutputImage>
+class OtsuStatistics : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Convenient typedefs for simplifying declarations. */

--- a/Modules/CLI/DWIJointRicianLMMSEFilter/itkOtsuThreshold.h
+++ b/Modules/CLI/DWIJointRicianLMMSEFilter/itkOtsuThreshold.h
@@ -19,7 +19,7 @@ namespace itk
 /** \class OtsuThreshold */
 
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT OtsuThreshold : public ImageToImageFilter<TInputImage, TOutputImage>
+class OtsuThreshold : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Convenient typedefs for simplifying declarations. */

--- a/Modules/CLI/DWIRicianLMMSEFilter/itkComputeRestrictedHistogram.h
+++ b/Modules/CLI/DWIRicianLMMSEFilter/itkComputeRestrictedHistogram.h
@@ -28,7 +28,7 @@ namespace itk
  * \brief Compute mean, std, min, and max of positive pixels
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT ComputeRestrictedHistogram : public ImageToImageFilter<TInputImage, TOutputImage>
+class ComputeRestrictedHistogram : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Convenient typedefs for simplifying declarations. */

--- a/Modules/CLI/DWIRicianLMMSEFilter/itkComputeStatisticsWherePositiveFilter.h
+++ b/Modules/CLI/DWIRicianLMMSEFilter/itkComputeStatisticsWherePositiveFilter.h
@@ -27,7 +27,7 @@ namespace itk
  * \brief Compute mean, std, min, and max of positive pixels
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT ComputeStatisticsWherePositiveFilter : public ImageToImageFilter<TInputImage, TOutputImage>
+class ComputeStatisticsWherePositiveFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Convenient typedefs for simplifying declarations. */

--- a/Modules/CLI/DWIRicianLMMSEFilter/itkExtractVolumeFilter.h
+++ b/Modules/CLI/DWIRicianLMMSEFilter/itkExtractVolumeFilter.h
@@ -27,7 +27,7 @@ namespace itk
  * \sa Image
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT ExtractVolumeFilter : public ImageToImageFilter<TInputImage, TOutputImage>
+class ExtractVolumeFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Standard class typedefs. */

--- a/Modules/CLI/DWIRicianLMMSEFilter/itkLMMSEVectorImageFilter.h
+++ b/Modules/CLI/DWIRicianLMMSEFilter/itkLMMSEVectorImageFilter.h
@@ -39,7 +39,7 @@ namespace itk
  * \ingroup IntensityImageFilters
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT LMMSEVectorImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
+class LMMSEVectorImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Convenient typedefs for simplifying declarations. */

--- a/Modules/CLI/DWIRicianLMMSEFilter/itkLMMSEVectorImageFilterStep.h
+++ b/Modules/CLI/DWIRicianLMMSEFilter/itkLMMSEVectorImageFilterStep.h
@@ -19,7 +19,7 @@ namespace itk
  */
 
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT LMMSEVectorImageFilterStep : public ImageToImageFilter<TInputImage, TOutputImage>
+class LMMSEVectorImageFilterStep : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Convenient typedefs for simplifying declarations. */

--- a/Modules/CLI/DWIRicianLMMSEFilter/itkMaskedMeanImageFilter.h
+++ b/Modules/CLI/DWIRicianLMMSEFilter/itkMaskedMeanImageFilter.h
@@ -40,7 +40,7 @@ namespace itk
  * \ingroup IntensityImageFilters
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT MaskedMeanImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
+class MaskedMeanImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Convenient typedefs for simplifying declarations. */

--- a/Modules/CLI/DWIRicianLMMSEFilter/itkVectorImageCastFilter.h
+++ b/Modules/CLI/DWIRicianLMMSEFilter/itkVectorImageCastFilter.h
@@ -43,7 +43,7 @@ public:
 }
 
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT VectorImageCastFilter :
+class VectorImageCastFilter :
   public UnaryFunctorImageFilter<TInputImage, TOutputImage,
                                  Function::Cast<typename TInputImage::PixelType, typename TOutputImage::PixelType>   >
 {

--- a/Modules/CLI/DWIUnbiasedNonLocalMeansFilter/itkComputeRestrictedHistogram.h
+++ b/Modules/CLI/DWIUnbiasedNonLocalMeansFilter/itkComputeRestrictedHistogram.h
@@ -28,7 +28,7 @@ namespace itk
  * \brief Compute mean, std, min, and max of positive pixels
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT ComputeRestrictedHistogram : public ImageToImageFilter<TInputImage, TOutputImage>
+class ComputeRestrictedHistogram : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Convenient typedefs for simplifying declarations. */

--- a/Modules/CLI/DWIUnbiasedNonLocalMeansFilter/itkOtsuStatistics.h
+++ b/Modules/CLI/DWIUnbiasedNonLocalMeansFilter/itkOtsuStatistics.h
@@ -19,7 +19,7 @@ namespace itk
  */
 
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT OtsuStatistics : public ImageToImageFilter<TInputImage, TOutputImage>
+class OtsuStatistics : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Convenient typedefs for simplifying declarations. */

--- a/Modules/CLI/DWIUnbiasedNonLocalMeansFilter/itkOtsuThreshold.h
+++ b/Modules/CLI/DWIUnbiasedNonLocalMeansFilter/itkOtsuThreshold.h
@@ -19,7 +19,7 @@ namespace itk
 /** \class OtsuThreshold */
 
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT OtsuThreshold : public ImageToImageFilter<TInputImage, TOutputImage>
+class OtsuThreshold : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Convenient typedefs for simplifying declarations. */

--- a/Modules/CLI/DWIUnbiasedNonLocalMeansFilter/itkUNLMFilter.h
+++ b/Modules/CLI/DWIUnbiasedNonLocalMeansFilter/itkUNLMFilter.h
@@ -47,7 +47,7 @@ bool UNLM_gradientDistance_smaller( OrderType e1, OrderType e2 )
  * \sa Image
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT UNLMFilter : public ImageToImageFilter<TInputImage, TOutputImage>
+class UNLMFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Standard class typedefs. */

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkAnisotropicSimilarity3DTransform.h
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkAnisotropicSimilarity3DTransform.h
@@ -49,7 +49,7 @@ namespace itk
  */
 template <class TScalarType = double>
 // Data type for scalars (float or double)
-class ITK_EXPORT AnisotropicSimilarity3DTransform :
+class AnisotropicSimilarity3DTransform :
   public VersorRigid3DTransform<TScalarType>
 {
 public:

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkAnisotropicSimilarityLandmarkBasedTransformInitializer.h
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkAnisotropicSimilarityLandmarkBasedTransformInitializer.h
@@ -56,7 +56,7 @@ namespace itk
 template <class TTransform,
           class TFixedImage,
           class TMovingImage>
-class ITK_EXPORT AnisotropicSimilarityLandmarkBasedTransformInitializer :
+class AnisotropicSimilarityLandmarkBasedTransformInitializer :
   public Object
 {
 public:

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageRegionMomentsCalculator.h
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageRegionMomentsCalculator.h
@@ -57,7 +57,7 @@ namespace itk
  * \todo It's not yet clear how multi-echo images should be handled here.
  */
 template <class TImage>
-class ITK_EXPORT ImageRegionMomentsCalculator : public Object
+class ImageRegionMomentsCalculator : public Object
 {
 public:
   /** Standard class typedefs. */

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageRegionMomentsCalculator.txx
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageRegionMomentsCalculator.txx
@@ -25,7 +25,7 @@
 namespace itk
 {
 
-class ITK_EXPORT InvalidImageRegionMomentsError : public ExceptionObject
+class InvalidImageRegionMomentsError : public ExceptionObject
 {
 public:
   /*

--- a/Modules/CLI/MRIBiasFieldCorrection/itkBSplineControlPointImageFilter.h
+++ b/Modules/CLI/MRIBiasFieldCorrection/itkBSplineControlPointImageFilter.h
@@ -65,7 +65,7 @@ namespace itk
  * Class definition for ParameterCostFunction
  */
 template <class TControlPointLattice>
-class ITK_EXPORT ParameterCostFunction
+class ParameterCostFunction
   : public SingleValuedCostFunction
 {
 public:

--- a/Modules/CLI/MRIBiasFieldCorrection/itkImageToVTKImageFilter.h
+++ b/Modules/CLI/MRIBiasFieldCorrection/itkImageToVTKImageFilter.h
@@ -38,7 +38,7 @@ namespace itk
  * \ingroup   ImageFilters
  */
 template <class TInputImage>
-class ITK_EXPORT ImageToVTKImageFilter : public ProcessObject
+class ImageToVTKImageFilter : public ProcessObject
 {
 public:
   /** Standard class typedefs. */

--- a/Modules/CLI/MRIBiasFieldCorrection/itkN3MRIBiasFieldCorrectionImageFilter.h
+++ b/Modules/CLI/MRIBiasFieldCorrection/itkN3MRIBiasFieldCorrectionImageFilter.h
@@ -89,7 +89,7 @@ namespace itk
 
 template <class TInputImage, class TBiasFieldImage, class TMaskImage,
           class TConfidenceImage>
-class ITK_EXPORT N3BiasFieldScaleCostFunction
+class N3BiasFieldScaleCostFunction
   : public SingleValuedCostFunction
 {
 public:
@@ -143,7 +143,7 @@ private:
 template <class TInputImage, class TMaskImage = Image<unsigned char,
                                                       ::itk::GetImageDimension<TInputImage>::ImageDimension>,
           class TOutputImage = TInputImage>
-class ITK_EXPORT N3MRIBiasFieldCorrectionImageFilter :
+class N3MRIBiasFieldCorrectionImageFilter :
   public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/Modules/CLI/MRIBiasFieldCorrection/itkN4MRIBiasFieldCorrectionImageFilter.h
+++ b/Modules/CLI/MRIBiasFieldCorrection/itkN4MRIBiasFieldCorrectionImageFilter.h
@@ -81,7 +81,7 @@ namespace itk
 template <class TInputImage, class TMaskImage = Image<unsigned char,
                                                       ::itk::GetImageDimension<TInputImage>::ImageDimension>,
           class TOutputImage = TInputImage>
-class ITK_EXPORT N4MRIBiasFieldCorrectionImageFilter :
+class N4MRIBiasFieldCorrectionImageFilter :
   public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/Modules/CLI/MRIBiasFieldCorrection/itkVTKImageToImageFilter.h
+++ b/Modules/CLI/MRIBiasFieldCorrection/itkVTKImageToImageFilter.h
@@ -41,7 +41,7 @@ namespace itk
  * \ingroup   ImageFilters
  */
 template <class TOutputImage>
-class ITK_EXPORT VTKImageToImageFilter : public ProcessObject
+class VTKImageToImageFilter : public ProcessObject
 {
 public:
   /** Standard class typedefs. */

--- a/Modules/CLI/MultiResolutionAffineRegistration/itkDecomposedAffine3DTransform.h
+++ b/Modules/CLI/MultiResolutionAffineRegistration/itkDecomposedAffine3DTransform.h
@@ -47,7 +47,7 @@ namespace itk
  */
 template <class TScalarType = double>
 // Data type for scalars:float or double
-class ITK_EXPORT DecomposedAffine3DTransform :
+class DecomposedAffine3DTransform :
   public Euler3DTransform<TScalarType>
 {
 public:

--- a/Modules/CLI/MultiResolutionAffineRegistration/itkEulerAnisotropicSimilarity3DTransform.h
+++ b/Modules/CLI/MultiResolutionAffineRegistration/itkEulerAnisotropicSimilarity3DTransform.h
@@ -47,7 +47,7 @@ namespace itk
  */
 template <class TScalarType = double>
 // Data type for scalars:float or double
-class ITK_EXPORT EulerAnisotropicSimilarity3DTransform :
+class EulerAnisotropicSimilarity3DTransform :
   public Euler3DTransform<TScalarType>
 {
 public:

--- a/Modules/CLI/MultiResolutionAffineRegistration/itkEulerSimilarity3DTransform.h
+++ b/Modules/CLI/MultiResolutionAffineRegistration/itkEulerSimilarity3DTransform.h
@@ -47,7 +47,7 @@ namespace itk
  */
 template <class TScalarType = double>
 // Data type for scalars:float or double
-class ITK_EXPORT EulerSimilarity3DTransform :
+class EulerSimilarity3DTransform :
   public Euler3DTransform<TScalarType>
 {
 public:

--- a/Modules/CLI/MultiResolutionAffineRegistration/itkFixedRotationSimilarity3DTransform.h
+++ b/Modules/CLI/MultiResolutionAffineRegistration/itkFixedRotationSimilarity3DTransform.h
@@ -50,7 +50,7 @@ namespace itk
  */
 template <class TScalarType = double>
 // Data type for scalars (float or double)
-class ITK_EXPORT FixedRotationSimilarity3DTransform :
+class FixedRotationSimilarity3DTransform :
   public Similarity3DTransform<TScalarType>
 {
 public:

--- a/Modules/CLI/MultiResolutionAffineRegistration/itkSlicerBoxSpatialObject.h
+++ b/Modules/CLI/MultiResolutionAffineRegistration/itkSlicerBoxSpatialObject.h
@@ -36,7 +36,7 @@ namespace itk
  *
  */
 template <unsigned int TDimension = 3>
-class ITK_EXPORT SlicerBoxSpatialObject
+class SlicerBoxSpatialObject
   : public SpatialObject<TDimension>
 {
 

--- a/Modules/CLI/N4ITKBiasFieldCorrection/SlicerITKv3BSplineControlPointImageFilter.h
+++ b/Modules/CLI/N4ITKBiasFieldCorrection/SlicerITKv3BSplineControlPointImageFilter.h
@@ -65,7 +65,7 @@ namespace itk
  * Class definition for ParameterCostFunction
  */
 template <class TControlPointLattice>
-class ITK_EXPORT ParameterCostFunction
+class ParameterCostFunction
   : public SingleValuedCostFunction
 {
 public:

--- a/Modules/CLI/N4ITKBiasFieldCorrection/SlicerITKv3N4MRIBiasFieldCorrectionImageFilter.h
+++ b/Modules/CLI/N4ITKBiasFieldCorrection/SlicerITKv3N4MRIBiasFieldCorrectionImageFilter.h
@@ -90,7 +90,7 @@ namespace itk
 template <class TInputImage, class TMaskImage =
             Image<unsigned char, ::itk::GetImageDimension<TInputImage>::ImageDimension>,
           class TOutputImage = TInputImage>
-class ITK_EXPORT N4MRIBiasFieldCorrectionImageFilter :
+class N4MRIBiasFieldCorrectionImageFilter :
   public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/Modules/CLI/ResampleDTIVolume/Testing/itkDifferenceDiffusionTensor3DImageFilter.h
+++ b/Modules/CLI/ResampleDTIVolume/Testing/itkDifferenceDiffusionTensor3DImageFilter.h
@@ -40,7 +40,7 @@ namespace itk
  * \ingroup IntensityImageFilters   Multithreaded
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT DifferenceDiffusionTensor3DImageFilter :
+class DifferenceDiffusionTensor3DImageFilter :
   public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/Modules/CLI/ResampleDTIVolume/dtiprocessFiles/itkHFieldToDeformationFieldImageFilter.h
+++ b/Modules/CLI/ResampleDTIVolume/dtiprocessFiles/itkHFieldToDeformationFieldImageFilter.h
@@ -44,7 +44,7 @@ namespace itk
  */
 template <typename TInputImage,
           typename TOutputImage = TInputImage>
-class ITK_EXPORT HFieldToDeformationFieldImageFilter :
+class HFieldToDeformationFieldImageFilter :
   public
   ImageToImageFilter<TInputImage, TOutputImage>
 {


### PR DESCRIPTION
The defintion of ITK_EXPORT was empty in all cases

This has been identified since 2003 as not being necessary
for builds. see https://issues.itk.org/jira/browse/ITK-3110

On Windows builds that need exports, they must
be unique per library, and that is not controlled by CMake now.

The PrintSelfCheck.tcl was the only remenant need for
This patch, and that is no longer being used, so that
file as been removed.

The ITK_EXPORT define was set to nothing and had no
known remaining purpose.  It was removed to make the
over all code easier to understand.  There was,
understandably, a bit of confusion about the
need for this being pervasive in the code.

It is currently backwards compatible to have
this in code, but at some future point it will
be removed.
