### PR TITLE
ENH: Updating SimpelITK version to 0.7.0.dev54

### DIFF
--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -17,11 +17,6 @@ set(SimpleITK_DEPENDENCIES ITKv4 Swig python)
 # Include dependent projects if any
 SlicerMacroCheckExternalProjectDependency(SimpleITK)
 
-#
-#  SimpleITK externalBuild
-#
-include(ExternalProject)
-
 set(EXTERNAL_PROJECT_OPTIONAL_ARGS)
 
 # Set CMake OSX variable to pass down the external project
@@ -58,18 +53,23 @@ configure_file(SuperBuild/SimpleITK_install_step.cmake.in
 
 set(SimpleITK_INSTALL_COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/SimpleITK_install_step.cmake)
 
+set(SimpleITK_REPOSITORY ${git_protocol}://itk.org/SimpleITK.git)
+# NOTE: If updating to a tag not on SimpleITK's master or release
+# branch update SimpleITK_BUILD_DISTRIBUTE flag below.
+set(SimpleITK_GIT_TAG d11d0454f55314beabf6fea564673a52ca983e4b ) #0.7.0.dev54
+
+
 
 ExternalProject_add(SimpleITK
   SOURCE_DIR SimpleITK
   BINARY_DIR SimpleITK-build
-  GIT_REPOSITORY ${git_protocol}://itk.org/SimpleITK.git
-  GIT_TAG v0.6.1
+  GIT_REPOSITORY ${SimpleITK_REPOSITORY}
+  GIT_TAG ${SimpleITK_GIT_TAG}
   CMAKE_ARGS
     -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
     -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
     -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
     -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
-    # SimpleITK does not work with shared libs turned on
     -DBUILD_SHARED_LIBS:BOOL=${Slicer_USE_SimpleITK_SHARED}
     -DSimpleITK_INSTALL_ARCHIVE_DIR:PATH=${Slicer_INSTALL_LIB_DIR}
     -DSimpleITK_INSTALL_LIBRARY_DIR:PATH=${Slicer_INSTALL_LIB_DIR}
@@ -86,6 +86,7 @@ ExternalProject_add(SimpleITK
     -DWRAP_CSHARP:BOOL=OFF
     -DWRAP_R:BOOL=OFF
     -DSWIG_EXECUTABLE:PATH=${SWIG_EXECUTABLE}
+    -DSimpleITK_BUILD_DISTRIBUTE:BOOL=ON # Shorten version and install path removing -g{GIT-HASH} suffix.
     ${EXTERNAL_PROJECT_OPTIONAL_ARGS}
   #
   INSTALL_COMMAND ${SimpleITK_INSTALL_COMMAND}


### PR DESCRIPTION
This update to SimpleITK includes the following:
 Fix for mantis 3157
 Improved compilation time with parallelism
 Improved VS9 compiler check
 Windows numpy size conversions fix

Additional tweaks to external file include:
 Adding cmake flag to remove git hash for version.
 Adding cmake variables for git tag and url.
