### PR TITLE
BUG: Fix #3214

### DIFF
--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManagerHelper.cxx
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManagerHelper.cxx
@@ -395,6 +395,38 @@ void vtkMRMLAnnotationDisplayableManagerHelper::RemoveWidgetAndNode(
     this->WidgetIntersections.erase(node);
   }
 
+  WidgetOverLineProjectionsIt widgetOverLineProjectionIterator = this->WidgetOverLineProjections.find(node);
+  if (widgetOverLineProjectionIterator != this->WidgetOverLineProjections.end()) {
+
+  if (this->WidgetOverLineProjections[node])
+    {
+    this->WidgetOverLineProjections[node]->Off();
+    this->WidgetOverLineProjections[node]->Delete();
+    }
+  this->WidgetOverLineProjections.erase(node);
+  }
+
+  WidgetUnderLineProjectionsIt widgetUnderLineProjectionIterator = this->WidgetUnderLineProjections.find(node);
+  if (widgetUnderLineProjectionIterator != this->WidgetUnderLineProjections.end()) {
+
+  if (this->WidgetUnderLineProjections[node])
+    {
+    this->WidgetUnderLineProjections[node]->Off();
+    this->WidgetUnderLineProjections[node]->Delete();
+    }
+  this->WidgetUnderLineProjections.erase(node);
+  }
+
+  WidgetPointProjectionsIt widgetPointProjectionIterator = this->WidgetPointProjections.find(node);
+  if (widgetPointProjectionIterator != this->WidgetPointProjections.end()) {
+
+  if (this->WidgetPointProjections[node])
+    {
+    this->WidgetPointProjections[node]->Off();
+    this->WidgetPointProjections[node]->Delete();
+    }
+  this->WidgetPointProjections.erase(node);
+  }
 
   vtkMRMLAnnotationDisplayableManagerHelper::AnnotationNodeListIt nodeIterator = std::find(
       this->AnnotationNodeList.begin(),


### PR DESCRIPTION
#3214: Hiding and deleting fiducials does not affect their 2d projections

The projection is creating object (vtkSeedWidget) to represent the projection on the 2D viewers. However, when the fiducial was removed, the vtkSeedWidget objects were staying, so projection was still visible.
In the RemoveWidgetAndNode, I forgot to include the code where the objects (vtkSeedWidget) related to the fiducial were deleted.
That's what I added here.
It's also true for rulers and their projection.
