### PR TITLE
Bug: Fix #3222

### DIFF
--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManager.cxx
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManager.cxx
@@ -873,13 +873,17 @@ void vtkMRMLAnnotationDisplayableManager::OnMRMLSliceNodeModifiedEvent(vtkMRMLSl
               rep->GetPoint2Representation()->GetSelectedProperty()->SetOpacity(0.0);
               rep->GetLineHandleRepresentation()->GetProperty()->SetOpacity(0.0);
               rep->GetLineHandleRepresentation()->GetSelectedProperty()->SetOpacity(0.0);
+              rep->GetLineProperty()->SetLineWidth(overLineWidth);
+              rep->GetLineHandleRepresentation()->DragableOff();
+              rep->GetLineHandleRepresentation()->PickableOff();
 
               overLine = vtkLineWidget2::New();
               overLine->CreateDefaultRepresentation();
               overLine->SetRepresentation(rep.GetPointer());
               overLine->SetInteractor(this->GetInteractor());
               overLine->SetCurrentRenderer(this->GetRenderer());
-              overLine->ProcessEventsOff();
+              overLine->ProcessEventsOff();	      
+              overLine->ManagesCursorOff();
               this->Helper->WidgetOverLineProjections[rulerNode] = overLine;
               }
 
@@ -901,13 +905,16 @@ void vtkMRMLAnnotationDisplayableManager::OnMRMLSliceNodeModifiedEvent(vtkMRMLSl
                 rep->GetLineHandleRepresentation()->GetProperty()->SetOpacity(0.0);
                 rep->GetLineHandleRepresentation()->GetSelectedProperty()->SetOpacity(0.0);
                 rep->GetLineProperty()->SetLineWidth(underLineWidth);
-
+                rep->GetLineHandleRepresentation()->DragableOff();
+                rep->GetLineHandleRepresentation()->PickableOff();
+	      
                 underLine = vtkLineWidget2::New();
                 underLine->CreateDefaultRepresentation();
                 underLine->SetRepresentation(rep.GetPointer());
                 underLine->SetInteractor(this->GetInteractor());
                 underLine->SetCurrentRenderer(this->GetRenderer());
                 underLine->ProcessEventsOff();
+                underLine->ManagesCursorOff();
                 this->Helper->WidgetUnderLineProjections[rulerNode] = underLine;
                 }
 
@@ -1088,6 +1095,7 @@ void vtkMRMLAnnotationDisplayableManager::OnMRMLSliceNodeModifiedEvent(vtkMRMLSl
             projectionSeed->SetCurrentRenderer(this->GetRenderer());
             projectionSeed->CreateNewHandle();
             projectionSeed->ProcessEventsOff();
+            projectionSeed->ManagesCursorOff();
             projectionSeed->On();
             projectionSeed->CompleteInteraction();
             this->Helper->WidgetPointProjections[fiducialNode] = projectionSeed;


### PR DESCRIPTION
#3222: moving mouse over moving ruler projection causes projection to turn green

When ruler is moving, projection seems to be selectable (color turn into green) when mouse is over it.
