### PR TITLE
ENH: adding SimpleFilters as internal modules via externalproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,11 @@ CMAKE_DEPENDENT_OPTION(
 mark_as_advanced(Slicer_BUILD_MultiVolumeExplorer)
 
 CMAKE_DEPENDENT_OPTION(
+  Slicer_BUILD_SimpleFilters "Build SimpleFilters." ON
+  "Slicer_BUILD_QTSCRIPTEDMODULES AND Slicer_USE_SimpleITK" OFF)
+mark_as_advanced(Slicer_BUILD_SimpleFilters)
+
+CMAKE_DEPENDENT_OPTION(
   Slicer_BUILD_BRAINSTOOLS "Build the BRAINS subset of registration and segmentation tools." ON
   "Slicer_BUILD_CLI_SUPPORT AND Slicer_BUILD_CLI" OFF)
 mark_as_advanced(Slicer_BUILD_BRAINSTOOLS)

--- a/Modules/Remote/CMakeLists.txt
+++ b/Modules/Remote/CMakeLists.txt
@@ -33,6 +33,15 @@ if(Slicer_BUILD_MultiVolumeImporter)
     )
 endif()
 
+
+if(Slicer_BUILD_SimpleFilters)
+  # NOTE: SimpleFilters source is checkout in Superbuild
+  add_subdirectory(
+    ${SimpleFilters_SOURCE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}/SimpleFilters
+    )
+endif()
+
 if(Slicer_BUILD_BRAINSTOOLS)
   # NOTE: BRAINSTools source code is checkout using "External_BRAINSTools.cmake".
   set(BRAINSTools_CLI_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${Slicer_CLIMODULES_LIB_DIR} CACHE PATH "" FORCE)

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -145,6 +145,10 @@ if(Slicer_BUILD_MultiVolumeImporter)
   list(APPEND Slicer_DEPENDENCIES MultiVolumeImporter)
 endif()
 
+if(Slicer_BUILD_SimpleFilters)
+  list(APPEND Slicer_DEPENDENCIES SimpleFilters)
+endif()
+
 if(Slicer_BUILD_DWIConvert)
   list(APPEND Slicer_DEPENDENCIES DWIConvert)
 endif()
@@ -288,6 +292,10 @@ endif()
 
 if(Slicer_BUILD_MultiVolumeImporter)
   list(APPEND EXTERNAL_PROJECT_OPTIONAL_ARGS -DMultiVolumeImporter_SOURCE_DIR:PATH=${MultiVolumeImporter_SOURCE_DIR})
+endif()
+
+if(Slicer_BUILD_SimpleFilters)
+  list(APPEND EXTERNAL_PROJECT_OPTIONAL_ARGS -DSimpleFilters_SOURCE_DIR:PATH=${SimpleFilters_SOURCE_DIR})
 endif()
 
 if(Slicer_BUILD_EMSegment)

--- a/SuperBuild/External_SimpleFilters.cmake
+++ b/SuperBuild/External_SimpleFilters.cmake
@@ -1,0 +1,41 @@
+
+# Make sure this file is included only once
+get_filename_component(CMAKE_CURRENT_LIST_FILENAME ${CMAKE_CURRENT_LIST_FILE} NAME_WE)
+if(${CMAKE_CURRENT_LIST_FILENAME}_FILE_INCLUDED)
+  return()
+endif()
+set(${CMAKE_CURRENT_LIST_FILENAME}_FILE_INCLUDED 1)
+
+# Sanity checks
+if(DEFINED SimpleFilters_SOURCE_DIR AND NOT EXISTS ${SimpleFilters_SOURCE_DIR})
+  message(FATAL_ERROR "SimpleFilters_SOURCE_DIR variable is defined but corresponds to non-existing directory")
+endif()
+
+# Set compile time dependency list
+set(SimpleFilters_DEPENDENCIES "")
+
+# Include dependent projects if any
+SlicerMacroCheckExternalProjectDependency(SimpleFilters)
+set(proj SimpleFilters)
+
+if(NOT DEFINED SimpleFilters_SOURCE_DIR)
+
+  if(NOT DEFINED git_protocol)
+    set(git_protocol "git")
+  endif()
+
+  ExternalProject_Add(${proj}
+    GIT_REPOSITORY "${git_protocol}://github.com/SimpleITK/SlicerSimpleFilters.git"
+    GIT_TAG "61f68b377d714b108b634d264d18a3108bdd6321"
+    SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
+    BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    DEPENDS
+      ${SimpleFilters_DEPENDENCIES}
+    )
+  set(SimpleFilters_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
+else()
+  SlicerMacroEmptyExternalProject(${proj} "${SimpleFilters_DEPENDENCIES}")
+endif()


### PR DESCRIPTION
Following the example of MultiVolumeImporter, a new external project
was added to download the SimpleFilters repository, the source
directory is propagated into the Slicer project and it is added as a
sub-directory to the build in scripted modules.
