### PR TITLE
STYLE: Use vtkQImageToImageSource.

### DIFF
--- a/Libs/MRML/Widgets/qMRMLUtils.cxx
+++ b/Libs/MRML/Widgets/qMRMLUtils.cxx
@@ -31,8 +31,10 @@
 #include <vtkMRMLViewNode.h>
 
 // VTK includes
-#include <vtkTransform.h>
 #include <vtkImageData.h>
+#include <vtkNew.h>
+#include <vtkQImageToImageSource.h>
+#include <vtkTransform.h>
 
 //-----------------------------------------------------------------------------
 qMRMLUtils::qMRMLUtils(QObject* _parent)
@@ -153,61 +155,11 @@ bool qMRMLUtils::qImageToVtkImageData(const QImage& qImage, vtkImageData* vtkima
     {
     return false;
     }
-
   QImage img = qImage;
-  if (qImage.hasAlphaChannel())
-    {
-    if (qImage.format() != QImage::Format_ARGB32)
-      {
-      img = qImage.convertToFormat(QImage::Format_ARGB32);
-      }
-    }
-  else
-    {
-    if (qImage.format() != QImage::Format_RGB32)
-      {
-      img = qImage.convertToFormat(QImage::Format_RGB32);
-      }
-    }
-
-  int height = img.height();
-  int width = img.width();
-  int numcomponents = img.hasAlphaChannel() ? 4 : 3;
-
-  vtkimage->SetWholeExtent(0, width-1, 0, height-1, 0, 0);
-  vtkimage->SetSpacing(1.0, 1.0, 1.0);
-  vtkimage->SetOrigin(0.0, 0.0, 0.0);
-  vtkimage->SetNumberOfScalarComponents(numcomponents);
-  vtkimage->SetScalarType(VTK_UNSIGNED_CHAR);
-  vtkimage->SetExtent(vtkimage->GetWholeExtent());
-  vtkimage->AllocateScalars();
-  for(int i=0; i<height; i++)
-    {
-    unsigned char* row;
-
-    row = static_cast<unsigned char*>(vtkimage->GetScalarPointer(0, height-i-1, 0));
-    const QRgb* linePixels = reinterpret_cast<const QRgb*>(img.scanLine(i));
-
-    /*
-     * TODO: consider using this to speed up the conversion:
-     *
-    memcpy(row, linePixels, width*numcomponents);
-    */
-
-    unsigned char* pixel;
-    pixel = row;
-    for(int j=0; j<width; j++)
-      {
-      const QRgb& col = linePixels[j];
-      *pixel++ = qRed(col);
-      *pixel++ = qGreen(col);
-      *pixel++ = qBlue(col);
-      if(numcomponents == 4)
-        {
-        *pixel++ = qAlpha(col);
-        }
-      }
-    }
+  vtkNew<vtkQImageToImageSource> converter;
+  converter->SetQImage(&img);
+  converter->Update();
+  vtkimage->DeepCopy(converter->GetOutput());
   return true;
 }
 


### PR DESCRIPTION
This method is now used internally within qMRMLUtils::qImageToVtkImageData.
