### PR TITLE
BUG: Explicitly disable using octave during Swig configure

### DIFF
--- a/SuperBuild/External_Swig.cmake
+++ b/SuperBuild/External_Swig.cmake
@@ -39,7 +39,7 @@ if(NOT SWIG_DIR)
     # not windows
 
     # Set dependency list
-    set(Swig_DEPENDENCIES "PCRE")
+    set(Swig_DEPENDENCIES PCRE python)
 
     # Include dependent projects if any
     SlicerMacroCheckExternalProjectDependency(Swig)

--- a/SuperBuild/swig_configure_step.cmake.in
+++ b/SuperBuild/swig_configure_step.cmake.in
@@ -21,6 +21,10 @@ set(ENV{YACC} "@BISON_EXECUTABLE@" )
 set(ENV{YFLAGS} "@BISON_FLAGS@" )
 
 execute_process(
-  COMMAND sh @swig_source_dir@/configure --prefix=@swig_install_dir@ --with-pcre-prefix=@pcre_install_dir@
+  COMMAND sh @swig_source_dir@/configure
+    --prefix=@swig_install_dir@
+    --with-pcre-prefix=@pcre_install_dir@
+    --without-octave
+    --with-python=@slicer_PYTHON_EXECUTABLE@
   WORKING_DIRECTORY @swig_binary_dir@
 )


### PR DESCRIPTION
Fix: #3294

Also explicitly specify Slicer python to swig configuration.
