### PR TITLE
BUG: fixed improper importing a series of dicom images.

### DIFF
--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx
@@ -734,49 +734,185 @@ void vtkITKArchetypeImageSeriesReader::ExecuteInformation()
   output->SetWholeExtent(extent);
   if (this->UseNativeScalarType)
     {
-      if (imageIO.GetPointer() == NULL) 
+    // If there is only one file in the series
+    if (this->FileNames.size() == 1)
       {
-      this->SetOutputScalarType(VTK_SHORT); // TODO - figure out why multi-file series doen't have an imageIO
+      if (imageIO.GetPointer() == NULL)
+        {
+        this->SetOutputScalarType(VTK_SHORT); // TODO - figure out why multi-file series doen't have an imageIO
+        }
+      else if (imageIO->GetComponentType() == itk::ImageIOBase::UCHAR)
+        {
+        this->SetOutputScalarType(VTK_UNSIGNED_CHAR);
+        }
+      else if (imageIO->GetComponentType() == itk::ImageIOBase::CHAR)
+        {
+        this->SetOutputScalarType(VTK_CHAR);
+        }
+      else if (imageIO->GetComponentType() == itk::ImageIOBase::USHORT)
+        {
+        this->SetOutputScalarType(VTK_UNSIGNED_SHORT);
+        }
+      else if (imageIO->GetComponentType() == itk::ImageIOBase::SHORT)
+        {
+        this->SetOutputScalarType(VTK_SHORT);
+        }
+      else if (imageIO->GetComponentType() == itk::ImageIOBase::UINT)
+        {
+        this->SetOutputScalarType(VTK_UNSIGNED_INT);
+        }
+      else if (imageIO->GetComponentType() == itk::ImageIOBase::INT)
+        {
+        this->SetOutputScalarType(VTK_INT);
+        }
+      else if (imageIO->GetComponentType() == itk::ImageIOBase::ULONG)
+        {
+        this->SetOutputScalarType(VTK_UNSIGNED_LONG);
+        }
+      else if (imageIO->GetComponentType() == itk::ImageIOBase::LONG)
+        {
+        this->SetOutputScalarType(VTK_LONG);
+        }
+      else if (imageIO->GetComponentType() == itk::ImageIOBase::FLOAT)
+        {
+        this->SetOutputScalarType(VTK_FLOAT);
+        }
+      else if (imageIO->GetComponentType() == itk::ImageIOBase::DOUBLE)
+        {
+        this->SetOutputScalarType(VTK_DOUBLE);
+        }
       }
-    else if (imageIO->GetComponentType() == itk::ImageIOBase::UCHAR)
+    else
       {
-      this->SetOutputScalarType(VTK_UNSIGNED_CHAR);
-      }
-    else if (imageIO->GetComponentType() == itk::ImageIOBase::CHAR)
-      {
-      this->SetOutputScalarType(VTK_CHAR);
-      }
-    else if (imageIO->GetComponentType() == itk::ImageIOBase::USHORT)
-      {
-      this->SetOutputScalarType(VTK_UNSIGNED_SHORT);
-      }
-    else if (imageIO->GetComponentType() == itk::ImageIOBase::SHORT)
-      {
-      this->SetOutputScalarType(VTK_SHORT);
-      }
-    else if (imageIO->GetComponentType() == itk::ImageIOBase::UINT)
-      {
-      this->SetOutputScalarType(VTK_UNSIGNED_INT);
-      }
-    else if (imageIO->GetComponentType() == itk::ImageIOBase::INT)
-      {
-      this->SetOutputScalarType(VTK_INT);
-      }
-    else if (imageIO->GetComponentType() == itk::ImageIOBase::ULONG)
-      {
-      this->SetOutputScalarType(VTK_UNSIGNED_LONG);
-      }
-    else if (imageIO->GetComponentType() == itk::ImageIOBase::LONG)
-      {
-      this->SetOutputScalarType(VTK_LONG);
-      }
-    else if (imageIO->GetComponentType() == itk::ImageIOBase::FLOAT)
-      {
-      this->SetOutputScalarType(VTK_FLOAT);
-      }
-    else if (imageIO->GetComponentType() == itk::ImageIOBase::DOUBLE)
-      {
-      this->SetOutputScalarType(VTK_DOUBLE);
+      double min = 0, max = 0;
+
+      for( unsigned int f = 0; f < this->FileNames.size(); f++ )
+        {
+        imageIO->SetFileName( this->FileNames[f] );
+        imageIO->ReadImageInformation();
+
+        if ( imageIO->GetComponentType() == itk::ImageIOBase::UCHAR )
+          {
+          min = std::numeric_limits<uint8_t>::min() < min ? std::numeric_limits<uint8_t>::min() : min;
+          max = std::numeric_limits<uint8_t>::max() > max ? std::numeric_limits<uint8_t>::max() : max;
+          }
+        if ( imageIO->GetComponentType() == itk::ImageIOBase::CHAR )
+          {
+          min = std::numeric_limits<int8_t>::min() < min ? std::numeric_limits<int8_t>::min() : min;
+          max = std::numeric_limits<int8_t>::max() > max ? std::numeric_limits<int8_t>::max() : max;
+          }
+        if ( imageIO->GetComponentType() == itk::ImageIOBase::USHORT )
+          {
+          min = std::numeric_limits<uint16_t>::min() < min ? std::numeric_limits<uint16_t>::min() : min;
+          max = std::numeric_limits<uint16_t>::max() > max ? std::numeric_limits<uint16_t>::max() : max;
+          }
+        if ( imageIO->GetComponentType() == itk::ImageIOBase::SHORT )
+          {
+          min = std::numeric_limits<int16_t>::min() < min ? std::numeric_limits<int16_t>::min() : min;
+          max = std::numeric_limits<int16_t>::max() > max ? std::numeric_limits<int16_t>::max() : max;
+          }
+        if ( imageIO->GetComponentType() == itk::ImageIOBase::UINT )
+          {
+          min = std::numeric_limits<uint32_t>::min() < min ? std::numeric_limits<uint32_t>::min() : min;
+          max = std::numeric_limits<uint32_t>::max() > max ? std::numeric_limits<uint32_t>::max() : max;
+          }
+        if ( imageIO->GetComponentType() == itk::ImageIOBase::INT )
+          {
+          min = std::numeric_limits<int32_t>::min() < min ? std::numeric_limits<int32_t>::min() : min;
+          max = std::numeric_limits<int32_t>::max() > max ? std::numeric_limits<int32_t>::max() : max;
+          }
+        if ( imageIO->GetComponentType() == itk::ImageIOBase::ULONG )
+          { // note that on windows ULONG is only 32 bit
+          min = std::numeric_limits<uint64_t>::min() < min ? std::numeric_limits<uint64_t>::min() : min;
+          max = std::numeric_limits<uint64_t>::max() > max ? std::numeric_limits<uint64_t>::max() : max;
+          }
+        if ( imageIO->GetComponentType() == itk::ImageIOBase::LONG )
+          { // note that on windows LONG is only 32 bit
+          min = std::numeric_limits<int64_t>::min() < min ? std::numeric_limits<int64_t>::min() : min;
+          max = std::numeric_limits<int64_t>::max() > max ? std::numeric_limits<int64_t>::max() : max;
+          }
+        if ( imageIO->GetComponentType() == itk::ImageIOBase::FLOAT )
+          {
+          // use -max() as min() for both float and double as temp workaround
+          // should switch to lowest() function in C++ 11 in the future
+          min = -std::numeric_limits<float>::max() < min ? -std::numeric_limits<float>::max() : min;
+          max = std::numeric_limits<float>::max() > max ? std::numeric_limits<float>::max() : max;
+          }
+        if ( imageIO->GetComponentType() == itk::ImageIOBase::DOUBLE )
+          {
+          min = -std::numeric_limits<double>::max() < min ? -std::numeric_limits<double>::max() : min;
+          max = std::numeric_limits<double>::max() > max ? std::numeric_limits<double>::max() : max;
+          }
+        }
+      assert( min <= max );
+      if( min >= 0 ) // unsigned
+        {
+        if( max <= std::numeric_limits<uint8_t>::max() )
+          {
+          this->SetOutputScalarType(VTK_UNSIGNED_CHAR);
+          }
+        else if( max <= std::numeric_limits<uint16_t>::max() )
+          {
+          this->SetOutputScalarType(VTK_UNSIGNED_SHORT);
+          }
+        else if( max <= std::numeric_limits<uint32_t>::max() )
+          {
+          this->SetOutputScalarType(VTK_UNSIGNED_INT);
+          }
+        else if( max <= std::numeric_limits<uint64_t>::max() )
+          {
+          this->SetOutputScalarType(VTK_UNSIGNED_LONG);
+          }
+        else if( max <= std::numeric_limits<float>::max() )
+          {
+          this->SetOutputScalarType(VTK_FLOAT);
+          }
+        else if( max <= std::numeric_limits<double>::max() )
+          {
+          this->SetOutputScalarType(VTK_DOUBLE);
+          }
+        else
+          {
+          assert(0);
+          }
+        }
+      else
+        {
+        if( max <= std::numeric_limits<int8_t>::max()
+          && min >= std::numeric_limits<int8_t>::min() )
+          {
+          this->SetOutputScalarType(VTK_CHAR);
+          }
+        else if( max <= std::numeric_limits<int16_t>::max()
+          && min >= std::numeric_limits<int16_t>::min() )
+          {
+          this->SetOutputScalarType(VTK_SHORT);
+          }
+        else if( max <= std::numeric_limits<int32_t>::max()
+          && min >= std::numeric_limits<int32_t>::min() )
+          {
+          this->SetOutputScalarType(VTK_INT);
+          }
+        else if( max <= std::numeric_limits<int64_t>::max()
+          && min >= std::numeric_limits<int64_t>::min() )
+          {
+          this->SetOutputScalarType(VTK_LONG);
+          }
+        else if ( max <= std::numeric_limits<float>::max()
+          && min >= -std::numeric_limits<float>::max() )
+          {
+          this->SetOutputScalarType(VTK_FLOAT);
+          }
+        else if( max <= std::numeric_limits<double>::max()
+          && min >= -std::numeric_limits<double>::max() )
+          {
+          this->SetOutputScalarType(VTK_DOUBLE);
+          }
+        else
+          {
+          assert(0);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Fixed issue when importing a series of dicom images, the scalar type is set incorrectly. A min and a max are used to check the scalar range now and determine the correct scalar type for importing image.
