### PR TITLE
EMH: Updating SimpleFilters internal module

### DIFF
--- a/SuperBuild/External_SimpleFilters.cmake
+++ b/SuperBuild/External_SimpleFilters.cmake
@@ -26,7 +26,7 @@ if(NOT DEFINED SimpleFilters_SOURCE_DIR)
 
   ExternalProject_Add(${proj}
     GIT_REPOSITORY "${git_protocol}://github.com/SimpleITK/SlicerSimpleFilters.git"
-    GIT_TAG "ceb1a619bf325a7b191eff0986eb74075966e8ac"
+    GIT_TAG "fc1f06ce52aec9272f928f3d1e0fa59b1a1c8bd6"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
This update just updates the json to those in SimpleITK v0.7rc1 and
removed filters not usable in Slicer related to ITK LabelMaps.

$ git log --oneline ceb1a6..fc1f06
fc1f06c BUG: Remove filters which take ITK LabelMap as input
016d7de Merge branch 'sitk-upstream' into update-sitk
74cbfcf SimpleITK e2ec6bbf Filter descriptions (reduced)

https://github.com/SimpleITK/SlicerSimpleFilters/compare/ceb1a6...fc1f06
