### PR TITLE
BUG: MGHImageIO CanReadFile Not Smart Enough.

### DIFF
--- a/Libs/MGHImageIO/itkMGHImageIO.cxx
+++ b/Libs/MGHImageIO/itkMGHImageIO.cxx
@@ -90,7 +90,8 @@ MGHImageIO::~MGHImageIO()
 }
 
 bool
-MGHImageIO::CanReadFile(const char* FileNameToRead)
+MGHImageIO
+::CanReadFile(const char* FileNameToRead)
 {
   const std::string filename(FileNameToRead);
 
@@ -101,10 +102,13 @@ MGHImageIO::CanReadFile(const char* FileNameToRead)
     }
 
   // check if the correct extension is given by the user
-  const std::string extension = itksys::SystemTools::GetFilenameExtension(filename.c_str());
-  if( extension == __MGH_EXT || this->IsCompressedFilename(filename) )
+  if(filename.size() > 4)
     {
-    return true;
+    const std::string extension = filename.substr(filename.size() - 4,4);
+    if( extension == __MGH_EXT || this->IsCompressedFilename(filename) )
+      {
+      return true;
+      }
     }
   return false;
 }
@@ -522,10 +526,40 @@ MGHImageIO::Write(const void* buffer)
 }
 
 bool
-MGHImageIO::IsCompressedFilename(const std::string fname)
+MGHImageIO
+::IsCompressedFilename(const std::string fname)
 {
-  const std::string extension = itksys::SystemTools::GetFilenameExtension(fname.c_str());
-  return extension == __MGZ_EXT || extension == __GZ_EXT || extension == __MGHGZ_EXT;
+  // this is actually working logic that searches for
+  // extensions ".mgz", ".gz", and ".mgh.gz"
+  //
+  // There's something wrong with this logic, since it in
+  // effect will say it can read ANY gzipped files, but since there's
+  // no unique file signature in a MGH file were're kind of stuck.
+  if(fname.size() >= 7)
+    {
+    std::string last7chars = fname.substr(fname.size() - 7,7);
+    if(last7chars == __MGHGZ_EXT)
+      {
+      return true;
+      }
+    else
+      {
+      std::string last4chars = fname.substr(fname.size() - 4, 4);
+      if(last4chars == __MGZ_EXT)
+        {
+        return true;
+        }
+      else
+        {
+        std::string last3chars = fname.substr(fname.size() - 3,3);
+        if(last3chars == __GZ_EXT)
+          {
+          return true ;
+          }
+        }
+      }
+    }
+  return false;
 }
 
 void


### PR DESCRIPTION
It couldn't handle a file that had '.' in the name before the actual
file extension.

NB: Christophe, I am unable to actually build slicer at the moment so I haven't built in place. I did, however, get it working in the ITK version and test it, and it should build clean in Slicer.
