### PR TITLE
ENH: Don't batch process when show/hide only a few child nodes

### DIFF
--- a/Libs/MRML/Widgets/qMRMLTreeView_p.h
+++ b/Libs/MRML/Widgets/qMRMLTreeView_p.h
@@ -25,6 +25,9 @@
 class QAction;
 class QMenu;
 
+// MRML includes
+class vtkMRMLHierarchyNode;
+
 // MRMLWidgets includes
 #include "qMRMLTreeView.h"
 class qMRMLSceneModel;
@@ -51,6 +54,9 @@ public:
   /// vtkMRMLDisplayableHierarchyNode
   void saveChildrenExpandState(QModelIndex& parentIndex);
   void scrollTo(const QString& name, bool next);
+
+  /// Returns true if the hierarchy node has mode children (and descendant) nodes than manyThreshold
+  static bool ManyChildrenNodes(vtkMRMLHierarchyNode* rootNode, int manyThreshold);
 
   qMRMLSceneModel*           SceneModel;
   qMRMLSortFilterProxyModel* SortFilterModel;


### PR DESCRIPTION
When there are many child nodes in a hierarchy then show/hide is much more efficient if batch processing is enabled.
However, if there are few nodes only then a full refresh at the end of a batch processing takes longer than doing the update on each node separately.
Count the number of child nodes and if there are less than 30 then update each node separately.
