### PR TITLE
COMP: rename GetJacobian() to make transform ITKv4 compliant

### DIFF
--- a/Libs/vtkITK/vtkITKBSplineTransform.cxx
+++ b/Libs/vtkITK/vtkITKBSplineTransform.cxx
@@ -844,7 +844,8 @@ ForwardTransformDerivativeHelper( vtkITKBSplineTransformHelperImpl<O>* helper,
     out[1] = -out[1];
     }
 
-  typename BSplineType::JacobianType jacobian = helper->BSpline->GetJacobian( inputPoint );
+  typename BSplineType::JacobianType jacobian;
+  helper->BSpline->ComputeJacobianWithRespectToParameters( inputPoint, jacobian );
   for( unsigned i=0; i<3; ++i )
   {
     derivative[i][0] = static_cast<T>( jacobian( i, 0 ) );
@@ -976,7 +977,8 @@ InverseTransformDerivativeHelper( vtkITKBSplineTransformHelperImpl<O>* helper,
     pt[1] = -pt[1];
     }
 
-  JacobianType const& jacobian = helper->BSpline->GetJacobian( pt );
+  JacobianType jacobian;
+  helper->BSpline->ComputeJacobianWithRespectToParameters( pt, jacobian );
   for( unsigned i=0; i<3; ++i )
   {
     derivative[i][0] = static_cast<T>( jacobian( i, 0 ) );


### PR DESCRIPTION
This patch is necessary to compile Slicer with a system ITKv4 library.

I don't think that the patch is backwards compatible to ITKv3, so please handle with care.

For more info see the ITKv4 migration guide.
http://itk.org/migrationv4/index.php?action=artikel&cat=3&id=110&artlang=en
