### PR TITLE
BUG: Fixed scene view node memory leak

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -1012,9 +1012,9 @@ vtkMRMLNode*  vtkMRMLScene::AddNodeNoNotify(vtkMRMLNode *n)
   // check if node is a singletone
   if (n->GetSingletonTag() != NULL)
     {
-    // check if there is a singletone of this class in the scene
+    // check if there is a singleton of this class in the scene
     // and if found copy this node into it
-    vtkMRMLNode *sn = this->GetSingletonNode(n->GetSingletonTag(), n->GetClassName());
+    vtkMRMLNode *sn = this->GetSingletonNode(n);
     if (sn != NULL)
       {
       // A node can't be added twice into the scene
@@ -1110,7 +1110,7 @@ vtkMRMLNode*  vtkMRMLScene::AddNode(vtkMRMLNode *n)
   // fired.
   bool add = true;
   if (n->GetSingletonTag() != NULL &&
-      this->GetSingletonNode(n->GetSingletonTag(), n->GetClassName()) != NULL)
+      this->GetSingletonNode(n) != NULL)
     {
     // if the node is a singleton, then it won't be added, just replaced
     add = false;
@@ -1506,6 +1506,43 @@ vtkMRMLNode* vtkMRMLScene::GetSingletonNode(const char* singletonTag, const char
 }
 
 //------------------------------------------------------------------------------
+vtkMRMLNode* vtkMRMLScene::GetSingletonNode(vtkMRMLNode* n)
+{
+  if (n->GetSingletonTag()==NULL)
+    {
+    vtkErrorMacro("vtkMRMLScene::GetSingletonNode failed: singleton node is expected");
+    return NULL;
+    }
+  vtkMRMLNode *sn = this->GetSingletonNode(n->GetSingletonTag(), n->GetClassName());
+  if (sn != NULL)
+    {
+    // singleton node found
+    return sn;
+    }
+
+  // No singleton node found, but it may be possible that a non-singleton node exists with
+  // the same ID, which is probably a singleton node where the tag was not set by mistake.
+  std::string singletonId=this->GenerateUniqueID(n);
+  sn=this->GetNodeByID(singletonId.c_str());
+  if (sn != NULL)
+  {
+    if (sn->GetSingletonTag()==NULL)
+      {
+      vtkWarningMacro("The "<<singletonId<<" ID belongs to a singleton, therefore it will be treated as a singleton");
+      }
+    else
+      {
+      vtkWarningMacro("The node ID "<<singletonId<<" is inconsistent with its singleton tag "<<sn->GetSingletonTag()
+        <<", the singleton tag is updated");
+      }
+    sn->SetSingletonTag(n->GetSingletonTag());
+    return sn;
+  }
+
+  return NULL;
+}
+
+//------------------------------------------------------------------------------
 vtkMRMLNode* vtkMRMLScene::GetNthNode(int n)
 {
 
@@ -1665,7 +1702,7 @@ vtkMRMLNode* vtkMRMLScene::GetNodeByID(const char* id)
       }
     if ( foundNode )
       {
-      vtkErrorMacro("GetNodeByID: No node found for ID: " << id);
+      vtkErrorMacro("GetNodeByID: Node is in the scene, but its ID is missing from the NodeIDs cache: " << id);
       }
     }
 #endif

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -207,6 +207,13 @@ public:
   /// tag. Return 0 if such node can't be found in the scene.
   vtkMRMLNode* GetSingletonNode(const char* singletonTag, const char* className);
 
+  /// Search and return a matching singleton in the scene that the input singleton
+  /// node will overwrite.if it is added to the scene.
+  /// There is matching if the singleton tag and className are the same,
+  /// or there is an existing node with the generated unique singleton node ID.
+  /// Return 0 if such node can't be found in the scene.
+  vtkMRMLNode* GetSingletonNode(vtkMRMLNode* n);
+
   std::list<std::string> GetNodeClassesList();
 
   /// Get the number of registered node classes (is probably greater than the current number

--- a/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
@@ -369,7 +369,7 @@ void vtkMRMLSceneViewNode::StoreScene()
     if (this->IncludeNodeInSceneView(node) &&
         node->GetSaveWithScene() )
       {
-      vtkMRMLNode *newNode = node->CreateNodeInstance();
+      vtkSmartPointer<vtkMRMLNode> newNode = vtkSmartPointer<vtkMRMLNode>::Take(node->CreateNodeInstance());
 
       newNode->SetScene(this->SnapshotScene);
       newNode->CopyWithoutModifiedEvent(node);
@@ -378,9 +378,6 @@ void vtkMRMLSceneViewNode::StoreScene()
       newNode->SetAddToSceneNoModify(1);
       this->SnapshotScene->AddNode(newNode);
       newNode->SetAddToSceneNoModify(0);
-
-      // Node has been added into the scene, decrease reference count to 1.
-      newNode->Delete();
 
       // sanity check
       assert(newNode->GetScene() == this->SnapshotScene);

--- a/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
+++ b/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
@@ -21,6 +21,8 @@
 vtkCxxRevisionMacro(vtkSlicerSceneViewsModuleLogic, "$Revision: 1.0$")
 vtkStandardNewMacro(vtkSlicerSceneViewsModuleLogic)
 
+const char SCENE_VIEW_TOP_LEVEL_SINGLETON_TAG[] = "SceneViewTopLevel";
+
 //-----------------------------------------------------------------------------
 // vtkSlicerSceneViewsModuleLogic methods
 //-----------------------------------------------------------------------------
@@ -95,7 +97,20 @@ void vtkSlicerSceneViewsModuleLogic::AddMissingHierarchyNodes()
     vtkMRMLSceneViewNode *sceneViewNode = vtkMRMLSceneViewNode::SafeDownCast(sceneViewNodes->GetItemAsObject(n));
     vtkMRMLHierarchyNode *hierarchyNode =  NULL;
     hierarchyNode = vtkMRMLHierarchyNode::GetAssociatedHierarchyNode(sceneViewNode->GetScene(), sceneViewNode->GetID());
-    if (!hierarchyNode)
+    if (hierarchyNode)
+      {
+      vtkMRMLHierarchyNode *topLevelNode=hierarchyNode->GetParentNode();
+      if (topLevelNode!=NULL)
+        {
+        if (topLevelNode->GetSingletonTag()==NULL)
+          {
+          // If the top-level hierarchy node is just read from the scene then it is not yet set up as a singleton.
+          // The top-level node has to be a singleton, so its singleton tag now.
+          topLevelNode->SetSingletonTag(SCENE_VIEW_TOP_LEVEL_SINGLETON_TAG);
+          }
+        }
+      }
+    else
       {
       vtkDebugMacro("AddMissingHierarchyNodes: missing a hierarchy node for scene view node " << sceneViewNode->GetID() << ", adding one");
       int retval = this->AddHierarchyNodeForNode(sceneViewNode);
@@ -648,43 +663,37 @@ char * vtkSlicerSceneViewsModuleLogic::GetTopLevelHierarchyNodeID(vtkMRMLNode* n
     return NULL;
     }
   
-  const char *toplevelTag = "SceneViewTopLevel";
- 
-  char *toplevelNodeID = NULL;
-
-  vtkMRMLHierarchyNode* toplevelNode = NULL;
-  vtkMRMLNode *mrmlNode = this->GetMRMLScene()->GetSingletonNode(toplevelTag, "vtkMRMLHierarchyNode");
-  if (mrmlNode)
-    {
-    toplevelNode = vtkMRMLHierarchyNode::SafeDownCast(mrmlNode);
-    }
-
-  if (toplevelNode)
-    {
-    toplevelNodeID = toplevelNode->GetID();
-    }
-  else
+  vtkMRMLNode *toplevelNode = this->GetMRMLScene()->GetSingletonNode(SCENE_VIEW_TOP_LEVEL_SINGLETON_TAG, "vtkMRMLHierarchyNode");
+  if (!toplevelNode)
     {
     // there wasn't a top level node, create one
     vtkDebugMacro("GetTopLevelHierarchyNode: no top level node, making new" );
-    toplevelNode = vtkMRMLHierarchyNode::New();
-    toplevelNode->SetSingletonTag(toplevelTag);
-    toplevelNode->HideFromEditorsOff();
-    toplevelNode->SetName("Scene Views");
-    toplevelNode->SetAttribute("SceneViewHierarchy", "true");
-
+    vtkSmartPointer<vtkMRMLHierarchyNode> createdToplevelNode = vtkSmartPointer<vtkMRMLHierarchyNode>::New();
+    createdToplevelNode->SetSingletonTag(SCENE_VIEW_TOP_LEVEL_SINGLETON_TAG);
+    createdToplevelNode->HideFromEditorsOff();
+    createdToplevelNode->SetName("Scene Views");
+    createdToplevelNode->SetAttribute("SceneViewHierarchy", "true");
     if (!node)
       {
-      this->GetMRMLScene()->AddNode(toplevelNode);
+      toplevelNode = this->GetMRMLScene()->AddNode(createdToplevelNode);
       }
     else
       {
-      this->GetMRMLScene()->InsertBeforeNode(node,toplevelNode);
+      toplevelNode = this->GetMRMLScene()->InsertBeforeNode(node,createdToplevelNode);
       }
-    toplevelNodeID = toplevelNode->GetID();
-    vtkDebugMacro("Added a new top level node with id " << toplevelNodeID << " and name " << toplevelNode->GetName());
-    toplevelNode->Delete();
+    if (toplevelNode)
+      {
+      vtkDebugMacro("Added a new top level node with id " << toplevelNode->GetID()
+        << " and name " << ( toplevelNode->GetName() ? toplevelNode->GetName() : "undefined" ) );
+      }
+    else
+      {
+      vtkErrorMacro("Failed to add top-level scene view node");
+      }
+
     }
+  char *toplevelNodeID = ( toplevelNode ? toplevelNode->GetID() : NULL );
+
   // sanity check
   this->FlattenSceneViewsHierarchy(toplevelNodeID);
   


### PR DESCRIPTION
Fixes http://na-mic.org/Mantis/view.php?id=3515

Solution in this patch:
1. To prevent having a singleton and a non-singleton node in the scene with the same ID: When we look for a singleton node we check if we can find any non-singleton node that has an ID that matches the singleton node ID. If a non-singleton-node with a singleton ID is found then that non-singleton-node is converted to singleton and a warning is logged.
2. To prevent logging a warning due to missing singleton tag: if the singleton node tag is missing for SceneViewTopLevel node then we add it in vtkSlicerSceneViewsModuleLogic.

A nicer solution would be to make a new class for SceneViewTopLevel node and set it as a singleton node in its constructor. However, we would still need to have the singleton node adding workaround for old scene files.
