### PR TITLE
BUG: Added missing node references update to scene->AddNode methods

### DIFF
--- a/Libs/MRML/Core/vtkMRMLModelNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLModelNode.cxx
@@ -592,7 +592,10 @@ vtkMRMLStorageNode* vtkMRMLModelNode::CreateDefaultStorageNode()
 //---------------------------------------------------------------------------
 void vtkMRMLModelNode::OnNodeReferenceAdded(vtkMRMLNodeReference *reference)
 {
-  this->UpdateDisplayNodePolyData(vtkMRMLDisplayNode::SafeDownCast(reference->ReferencedNode));
+  if (std::string(reference->GetReferenceRole()) == this->DisplayNodeReferenceRole)
+    {
+    this->UpdateDisplayNodePolyData(vtkMRMLDisplayNode::SafeDownCast(reference->ReferencedNode));
+    }
   Superclass::OnNodeReferenceAdded(reference);
 }
 

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -1055,6 +1055,11 @@ vtkMRMLNode*  vtkMRMLScene::AddNodeNoNotify(vtkMRMLNode *n)
       oldID = n->GetID();
       }
     n->SetID(this->GenerateUniqueID(n).c_str());
+    if (n->GetScene())
+      {
+      // The scene is set already so update the ID references for this new ID
+      n->SetSceneReferences();
+      }
 
     vtkDebugMacro("AddNodeNoNotify: got unique id for new " << n->GetClassName() << " node: " << n->GetID() << endl);
     std::string newID(n->GetID());
@@ -1774,6 +1779,11 @@ vtkMRMLNode* vtkMRMLScene::InsertAfterNode(vtkMRMLNode *item, vtkMRMLNode *n)
     int modifyStatus = n->GetDisableModifiedEvent();
     n->SetDisableModifiedEvent(1);
     n->SetID(this->GenerateUniqueID(n).c_str());
+    if (n->GetScene())
+      {
+      // The scene is set already so update the ID references for this new ID
+      n->SetSceneReferences();
+      }
     n->SetDisableModifiedEvent(modifyStatus);
     std::string newID(n->GetID());
     if (oldID != newID)
@@ -1853,6 +1863,11 @@ vtkMRMLNode* vtkMRMLScene::InsertBeforeNode(vtkMRMLNode *item, vtkMRMLNode *n)
     int modifyStatus = n->GetDisableModifiedEvent();
     n->SetDisableModifiedEvent(1);
     n->SetID(this->GenerateUniqueID(n).c_str());
+    if (n->GetScene())
+      {
+      // The scene is set already so update the ID references for this new ID
+      n->SetSceneReferences();
+      }
     n->SetDisableModifiedEvent(modifyStatus);
     std::string newID(n->GetID());
     if (oldID != newID)
@@ -2626,12 +2641,32 @@ void vtkMRMLScene::ClearRedoStack()
 //------------------------------------------------------------------------------
 void vtkMRMLScene::AddReferencedNodeID(const char *id, vtkMRMLNode *referencingNode)
 {
-  if (id && referencingNode &&
-      referencingNode->GetScene() && referencingNode->GetID() &&
-      !this->IsNodeReferencingNodeID(referencingNode, id))
+  if (id==NULL)
     {
-    this->NodeReferences[id].insert(referencingNode->GetID());
+    // vtkErrorMacro("Failed to add node reference: invalid referenced node ID");
+    // Do not log an error for now, because many places there are calls like
+    //   this->Scene->AddReferencedNodeID(this->ActiveVolumeID, this);
+    // TODO: replace manual reference handling by proper node references
+    //   then this error checking can be activated.
+    return;
     }
+  if (referencingNode==NULL)
+    {
+    vtkErrorMacro("Failed to add node reference: the referencing node is invalid");
+    return;
+    }
+  if (referencingNode->GetScene()==NULL || referencingNode->GetID()==NULL)
+    {
+    // Scene is not yet set for the referencing node, so we don't need to add the reference to the scene yet.
+    // When the scene will be set then all the references will be added.
+    return;
+    }
+  if (this->IsNodeReferencingNodeID(referencingNode, id))
+    {
+    // this reference already exists, there is nothing to do
+    return;
+    }
+  this->NodeReferences[id].insert(referencingNode->GetID());
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -275,18 +275,12 @@ public:
   void SaveStateForUndo(vtkCollection *nodes);
   void SaveStateForUndo(std::vector<vtkMRMLNode *> nodes);
 
-  /// The Scene maintains two lists that keep track of the relationship
+  /// The Scene maintains a map (NodeReferences) to keep track of the relationship
   /// between node IDs and the nodes referencing those IDs.  Each
   /// node can use the call AddReferencedNodeID to tell the scene
   /// that is 'has an interest' in the given ID so that the scene
   /// can notify that node when the ID has been remapped.   It does
   /// this notification through the UpdateNodeReferences call.
-  /// The two lists (std::vectors) are ReferencingNodes and ReferencedIDs,
-  /// which (usually) contain the same number of elements and the
-  /// entries should correspond; they can be different during update.
-  /// The ReferencingNodes is a vector of smart pointers,
-  /// so that the nodes are not freed until they are no longer
-  /// used by these lists.
   void AddReferencedNodeID(const char *id, vtkMRMLNode *refrencingNode);
   bool IsNodeReferencingNodeID(vtkMRMLNode* referencingNode, const char* id);
 


### PR DESCRIPTION
Fixes http://na-mic.org/Mantis/view.php?id=3539.

Problem was that node references were not updated in the scene when node->SetScene(scene) was called for the node before scene->AddNode(node).

A few more code fixes are also included (no functional change, just making the code cleaner).
