### PR TITLE
BUG: Protect FilterWatcher from Progress before Start events

### DIFF
--- a/Base/CLI/itkPluginFilterWatcher.h
+++ b/Base/CLI/itkPluginFilterWatcher.h
@@ -62,10 +62,17 @@ virtual void ShowProgress()
           m_ProcessInformation->StageProgress = this->GetProcess()->GetProgress();
           }
 
-        this->GetTimeProbe().Stop();
-        m_ProcessInformation->ElapsedTime
-          = this->GetTimeProbe().GetMean()
-          * this->GetTimeProbe().GetNumberOfStops();
+        try
+          {
+          this->GetTimeProbe().Stop();
+          m_ProcessInformation->ElapsedTime
+            = this->GetTimeProbe().GetMean()
+            * this->GetTimeProbe().GetNumberOfStops();
+          }
+        catch(...)
+          {
+          // ignore time probe exceptions
+          }
         this->GetTimeProbe().Start();
 
         if (m_ProcessInformation->Abort)


### PR DESCRIPTION
If the ShowProgress method is observed before StartFilter the ITK
time probe will be stopped before the it's started. This causes an
exception. This case is just caught and ignored.

This issue was detected with the itk::StreamingImageFilter.
