### PR TITLE
BUG: Add escape sequence to quotes in CMake string

### DIFF
--- a/Extensions/CMake/SlicerFunctionGenerateExtensionDescription.cmake
+++ b/Extensions/CMake/SlicerFunctionGenerateExtensionDescription.cmake
@@ -97,7 +97,7 @@ scmrevision ${MY_EXTENSION_WC_REVISION}
 # - The dependencies will be built first
 depends     ${MY_EXTENSION_DEPENDS}
 
-# Inner build directory (default is ".")
+# Inner build directory (default is \".\")
 build_subdirectory ${MY_EXTENSION_BUILD_SUBDIRECTORY}
 
 # homepage


### PR DESCRIPTION
With: cmake version 2.8.12.1

I was getting the following warning:

Make Warning (dev) at /Users/blowekamp/src/Slicer/CMake/SlicerExtensionCPack.cmake:61 (include):
  Syntax Warning in cmake code at

```
/Users/blowekamp/src/Slicer/Extensions/CMake/SlicerFunctionGenerateExtensionDescription.cmake:100:38
```

  Argument not separated from preceding token by whitespace.
Call Stack (most recent call first):
  CMakeLists.txt:73 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at /Users/blowekamp/src/Slicer/CMake/SlicerExtensionCPack.cmake:61 (include):
  Syntax Warning in cmake code at

```
/Users/blowekamp/src/Slicer/Extensions/CMake/SlicerFunctionGenerateExtensionDescription.cmake:100:39
```

  Argument not separated from preceding token by whitespace.
Call Stack (most recent call first):
  CMakeLists.txt:73 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
