### PR TITLE
ENH: Add 'pydicom' python module as external project.

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -109,6 +109,10 @@ if(Slicer_BUILD_DICOM_SUPPORT)
   list(APPEND Slicer_DEPENDENCIES DCMTK)
 endif()
 
+if(Slicer_BUILD_DICOM_SUPPORT AND Slicer_USE_PYTHONQT_WITH_OPENSSL)
+  list(APPEND Slicer_DEPENDENCIES pydicom)
+endif()
+
 if(Slicer_USE_BatchMake)
   list(APPEND Slicer_DEPENDENCIES BatchMake)
 endif()

--- a/SuperBuild/External_pydicom.cmake
+++ b/SuperBuild/External_pydicom.cmake
@@ -1,0 +1,32 @@
+set(proj pydicom)
+
+# Set dependency list
+set(${proj}_DEPENDENCIES python)
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
+
+if(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+  # XXX - Add a test checking if <proj> is available
+endif()
+
+if(NOT DEFINED ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+  set(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj} ${${CMAKE_PROJECT_NAME}_USE_SYSTEM_python})
+endif()
+
+if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+
+  ExternalProject_Add(${proj}
+    ${${proj}_EP_ARGS}
+    URL "http://pydicom.googlecode.com/files/pydicom-0.9.8.tar.gz"
+    URL_MD5 "e344ab5b38abeaa462ee79fa04c1c25f"
+    SOURCE_DIR ${proj}
+    BUILD_IN_SOURCE 1
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ${PYTHON_EXECUTABLE} setup.py install
+    DEPENDS
+      ${${proj}_DEPENDENCIES}
+    )
+
+endif()


### PR DESCRIPTION
"pydicom is a pure python package for working with DICOM files. It
was made for inspecting and modifying DICOM data in an easy "pythonic"
way. The modifications can be written again to a new file. As a pure
python package, it should run anywhere python runs without any other
requirements.

pydicom is not a DICOM server, and is not primarily about viewing
images. It is designed to let you manipulate data elements in DICOM
files with python code.

Limitations -- the main limitation of the current version is that
compressed pixel data (e.g. JPEG) cannot be altered in an intelligent
way as it can for uncompressed pixels. Files can always be read and
saved, but compressed pixel data cannot easily be modified."
See http://code.google.com/p/pydicom/

The module being licensed under MIT license, it is compatible with
the Slicer BSD like license.

Co-authored-by: Andriy Fedorov fedorov@bwh.harvard.edu
