### PR TITLE
Adding user-defined stereo-viewing options

### DIFF
--- a/Libs/MRML/Core/vtkMRMLViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLViewNode.cxx
@@ -162,7 +162,19 @@ void vtkMRMLViewNode::WriteXML(ostream& of, int nIndent)
     {
     of << indent << " stereoType=\"" << "Interlaced" << "\"";    
     }
-
+  else if ( this->GetStereoType() == vtkMRMLViewNode::UserDefined_1 )
+    {
+    of << indent << " stereoType=\"" << "UserDefined_1" << "\"";    
+    }
+  else if ( this->GetStereoType() == vtkMRMLViewNode::UserDefined_2 )
+    {
+    of << indent << " stereoType=\"" << "UserDefined_2" << "\"";    
+    }
+  else if ( this->GetStereoType() == vtkMRMLViewNode::UserDefined_3 )
+    {
+    of << indent << " stereoType=\"" << "UserDefined_3" << "\"";    
+    }
+    
   // configure render mode
   if (this->GetRenderMode() == vtkMRMLViewNode::Perspective )
     {
@@ -282,6 +294,18 @@ void vtkMRMLViewNode::ReadXMLAttributes(const char** atts)
       else if ( !strcmp (attValue, "Interlaced" ))
         {
         this->StereoType = vtkMRMLViewNode::Interlaced;
+        }
+      else if ( !strcmp (attValue, "UserDefined_1" ))
+        {
+        this->StereoType = vtkMRMLViewNode::UserDefined_1;
+        }
+      else if ( !strcmp (attValue, "UserDefined_2" ))
+        {
+        this->StereoType = vtkMRMLViewNode::UserDefined_2;
+        }
+      else if ( !strcmp (attValue, "UserDefined_3" ))
+        {
+        this->StereoType = vtkMRMLViewNode::UserDefined_3;
         }
       }
     else if (!strcmp(attName, "rockLength" ))

--- a/Libs/MRML/Core/vtkMRMLViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLViewNode.h
@@ -170,7 +170,10 @@ public:
       RedBlue,
       Anaglyph,
       QuadBuffer,
-      Interlaced
+      Interlaced,
+      UserDefined_1,
+      UserDefined_2,
+      UserDefined_3
     };
 
   /// render modes

--- a/Libs/MRML/DisplayableManager/vtkMRMLViewDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewDisplayableManager.cxx
@@ -483,6 +483,18 @@ void vtkMRMLViewDisplayableManager::vtkInternal::UpdateStereoType()
     {
     renderWindow->SetStereoTypeToInterlaced();
     }
+  else if (stereoType == vtkMRMLViewNode::UserDefined_1)
+    {
+    renderWindow->SetStereoType(101);
+    }
+  else if (stereoType == vtkMRMLViewNode::UserDefined_2)
+    {
+    renderWindow->SetStereoType(102);
+    }
+  else if (stereoType == vtkMRMLViewNode::UserDefined_3)
+    {
+    renderWindow->SetStereoType(103);
+    }
 
   renderWindow->SetStereoRender(stereoType != vtkMRMLViewNode::NoStereo);
   this->External->RequestRender();

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLThreeDViewControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLThreeDViewControllerWidget.ui
@@ -24,14 +24,14 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="ctkAxesWidget" name="AxesWidget">
+    <widget class="ctkAxesWidget" name="AxesWidget" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Ignored">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="autoReset">
+     <property name="autoReset" stdset="0">
       <bool>true</bool>
      </property>
     </widget>
@@ -409,6 +409,39 @@
    </property>
    <property name="text">
     <string>Show/Hide frames per second (FPS)</string>
+   </property>
+  </action>
+  <action name="actionSwitchToUserDefinedStereo_1">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>User Defined 1</string>
+   </property>
+   <property name="toolTip">
+    <string>Switch to user defined stereo mode 1</string>
+   </property>
+  </action>
+  <action name="actionSwitchToUserDefinedStereo_2">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>User Defined 2</string>
+   </property>
+   <property name="toolTip">
+    <string>Switch to user defined stereo mode 2</string>
+   </property>
+  </action>
+  <action name="actionSwitchToUserDefinedStereo_3">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>User Defined 3</string>
+   </property>
+   <property name="toolTip">
+    <string>Switch to user defined stereo mode 3</string>
    </property>
   </action>
  </widget>

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
@@ -112,6 +112,12 @@ void qMRMLThreeDViewControllerWidgetPrivate::setupPopupUi()
                                       vtkMRMLViewNode::Interlaced);
   this->StereoTypesMapper->setMapping(this->actionSwitchToRedBlueStereo,
                                       vtkMRMLViewNode::RedBlue);
+  this->StereoTypesMapper->setMapping(this->actionSwitchToUserDefinedStereo_1,
+                                      vtkMRMLViewNode::UserDefined_1);
+  this->StereoTypesMapper->setMapping(this->actionSwitchToUserDefinedStereo_2,
+                                      vtkMRMLViewNode::UserDefined_2);
+  this->StereoTypesMapper->setMapping(this->actionSwitchToUserDefinedStereo_3,
+                                      vtkMRMLViewNode::UserDefined_3);                                      
   QActionGroup* stereoTypesActions = new QActionGroup(this->PopupWidget);
   stereoTypesActions->setExclusive(true);
   stereoTypesActions->addAction(this->actionNoStereo);
@@ -119,6 +125,9 @@ void qMRMLThreeDViewControllerWidgetPrivate::setupPopupUi()
   stereoTypesActions->addAction(this->actionSwitchToAnaglyphStereo);
   stereoTypesActions->addAction(this->actionSwitchToInterlacedStereo);
   stereoTypesActions->addAction(this->actionSwitchToQuadBufferStereo);
+  stereoTypesActions->addAction(this->actionSwitchToUserDefinedStereo_1);
+  stereoTypesActions->addAction(this->actionSwitchToUserDefinedStereo_2);
+  stereoTypesActions->addAction(this->actionSwitchToUserDefinedStereo_3);
   QMenu* stereoTypesMenu = new QMenu("Stereo Modes", this->PopupWidget);
   stereoTypesMenu->setObjectName("stereoTypesMenu");
   stereoTypesMenu->addActions(stereoTypesActions->actions());


### PR DESCRIPTION
As discussed during NA-MIC week, added user-defined stereo-viewing options to make easier the adding of support for new stereoscopic 3D devices.
