### PR TITLE
ENH: Make layoutManager() method in qMRMLLayoutWidget Q_INVOKABLE

### DIFF
--- a/Libs/MRML/Widgets/qMRMLLayoutWidget.h
+++ b/Libs/MRML/Widgets/qMRMLLayoutWidget.h
@@ -46,7 +46,7 @@ public:
   virtual ~qMRMLLayoutWidget();
 
   /// Layout manager
-  qMRMLLayoutManager* layoutManager()const;
+  Q_INVOKABLE qMRMLLayoutManager* layoutManager()const;
   /// Utility function that returns the mrml scene of the layout manager
   vtkMRMLScene* mrmlScene()const;
   /// Utility function that returns the current layout of the layout manager


### PR DESCRIPTION
To make it accessible from python
