### PR TITLE
ENH: Updating SimpleFilter remote module

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -191,7 +191,7 @@ list_conditional_append(Slicer_BUILD_MultiVolumeImporter Slicer_REMOTE_DEPENDENC
 
 Slicer_Remote_Add(SimpleFilters
   GIT_REPOSITORY ${git_protocol}://github.com/SimpleITK/SlicerSimpleFilters.git
-  GIT_TAG fc1f06ce52aec9272f928f3d1e0fa59b1a1c8bd6
+  GIT_TAG 3bc2fdc5ca5c72b3fbfc596213eecf89cec31b32
   OPTION_NAME Slicer_BUILD_SimpleFilters
   OPTION_DEPENDS "Slicer_BUILD_QTSCRIPTEDMODULES;Slicer_USE_SimpleITK"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
This updates adds a check box to set output as LabelMap, A Restore
defaults button, and print of filter to be run in python code to set
filter.

$ git log --oneline fc1f06..3bc2f
3bc2fdc Adding button "Restore" defaults
0d27412 ENH: improving responsiveness of main_queue_process
51d14b7 STYLE: move apply bottom to match CLI interface
49ec882 ENH: print object oriented python code to create filter before running
5d0a528 ENH: When a labelmap input is selected the output changes to labelmap
aa7ddc5 Update node selector and checkbox with LabelMap state
d4a5116 move output box and labelmap checkbox to self variables
648f736 Adding CheckBox to set output volume as label map
