### PR TITLE
ENH: Disable slice view reset (volume propagation) if CLI Autorun is enabled

### DIFF
--- a/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
+++ b/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
@@ -2288,6 +2288,16 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
         // now, he/she will still be looking at the node by the time the
         // data is reloaded by the main thread.
         bool displayData = this->IsCommandLineModuleNodeUpdatingDisplay(node0);
+
+        // displayData causes resetting of slice views (the output volume is shown in the background,
+        // the foreground volume is cleared, the middle slice is selected, the FOV is reset, etc.)
+        // which is not desirable when AutoRun is enabled (because the user already set up the
+        // slice viewers for optimal viewing)
+        if (node0->GetAutoRun())
+        {
+          displayData=false;
+        }
+
         bool deleteFile = this->GetDeleteTemporaryFiles();
         int requestUID = this->GetApplicationLogic()
           ->RequestReadData((*id2fn0).first.c_str(), (*id2fn0).second.c_str(),


### PR DESCRIPTION
Disable slice view reset (volume propagation) is important, because when we change a CLI parameter we want to keep all the carefully chosen slice view settings (background/foreground volume selection, slice selection, transparency, zoom, etc.). Before this change all the slice view settings had to be set again after each parameter change, which basically rendered the Autorun feature useless for modules with volume output.
