### PR TITLE
BUG: Fixed various errors in the save scene dialog for mrb format

### DIFF
--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -300,6 +300,9 @@ void qSlicerSaveDataDialogPrivate::populateItems()
   // MRML scene the first item of the list so we don't do restore the sorting.
   // this->FileWidget->setSortingEnabled(oldSortingEnabled);
 
+  // Enable/disable nodes depending on the scene file format
+  this->onSceneFormatChanged();
+
   this->updateSize();
 }
 
@@ -322,7 +325,7 @@ void qSlicerSaveDataDialogPrivate::populateScene()
     {
     sceneFileInfo = QFileInfo( QDir(this->MRMLScene->GetRootDirectory()),
                                QDate::currentDate().toString(
-                                 "yyyy-MM-dd") + "-Scene");
+                                 "yyyy-MM-dd") + "-Scene.mrml");
     }
 
   // Scene Name
@@ -374,7 +377,8 @@ void qSlicerSaveDataDialogPrivate::populateScene()
 
   // Scene Directory
   ctkDirectoryButton* sceneDirectoryButton =
-      this->createFileDirectoryWidget(QFileInfo(this->MRMLScene->GetRootDirectory()));
+      this->createFileDirectoryWidget(sceneFileInfo);
+
   this->FileWidget->setCellWidget(row, FileDirectoryColumn, sceneDirectoryButton);
 
   // Scene Selected


### PR DESCRIPTION
There were 3 problems:
1. When the save scene dialog is shown first, the file format selector is empty
2. When a scene is saved as .mrb and then the save dialog is opened again the format is still .mrb, but the populated items are not disabled
3. When a scene is saved as .mrb and then the save dialog is opened again the target directory is not the same (it’s the parent directory of the directory where the scene was saved the last time)
