### PR TITLE
ENH: Update SimpleITK 0.8.0 release

### DIFF
--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -25,7 +25,7 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   set(SimpleITK_INSTALL_COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/SimpleITK_install_step.cmake)
 
   set(SimpleITK_REPOSITORY ${git_protocol}://itk.org/SimpleITK.git)
-  set(SimpleITK_GIT_TAG v0.8rc1 )
+  set(SimpleITK_GIT_TAG v0.8.0)
 
   ExternalProject_add(SimpleITK
     ${${proj}_EP_ARGS}

--- a/SuperBuild/SimpleITK_install_step.cmake.in
+++ b/SuperBuild/SimpleITK_install_step.cmake.in
@@ -3,15 +3,6 @@ set(ENV{LD_LIBRARY_PATH} "@slicer_PYTHON_SHARED_LIBRARY_DIR@")
 set(ENV{DYLD_LIBRARY_PATH} "@slicer_PYTHON_SHARED_LIBRARY_DIR@")
 set(ENV{VS_UNICODE_OUTPUT} "")
 
-# HACK
-# Slicer's python does not support https, where pipy has
-# distribute. So we manually download the specific version into the
-# SimpleITK build tree.
-file(DOWNLOAD  "http://midas3.kitware.com/midas/download/item/208573/distribute-0.6.28.tar.gz"
-  "@CMAKE_CURRENT_BINARY_DIR@/SimpleITK-build/Wrapping/distribute-0.6.28.tar.gz"
-  EXPECTED_MD5 b400b532e33f78551e6847c1f5965e56
-  )
-
 # The working path must be set to the location of the SimpleITK.py
 # file so that it will be picked up by distuils setup, and installed
 execute_process(


### PR DESCRIPTION
The manual download of distribute has been removed. The new
ez_setup.py file for fulfilling the setuptools requirement for
SimpleITK's setup.py file not can utilize PowerShell,curl and wget to
download the required setuptools package of https.
