### PR TITLE
COMP: Error due to imporoper linkage specification

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSliceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.h
@@ -84,7 +84,7 @@ class VTK_MRML_EXPORT vtkMRMLSliceNode : public vtkMRMLAbstractViewNode
   /// Get number of View Node ID's for the view to display this node in.
   /// If 0, display in all views
   /// \sa ThreeDViewIDs, GetThreeDViewIDs(), AddThreeDViewID()
-  inline int GetNumberOfThreeDViewIDs()const;
+  int GetNumberOfThreeDViewIDs()const;
   /// Get View Node ID's for the view to display this node in.
   /// If NULL, display in all views
   /// \sa ThreeDViewIDs, GetThreeDViewIDs(), AddThreeDViewID()


### PR DESCRIPTION
inline functions are required to be declared and defined
in the same scope.  The inline specifier changed the linkage
signature an prevented this from compiling.

Undefined symbols for architecture x86_64:
  "vtkMRMLSliceNode::GetNumberOfThreeDViewIDs() const", referenced from:
      PyvtkMRMLSliceNode_GetNumberOfThreeDViewIDs(_object_, _object_) in vtkMRMLSliceNodePython.cxx.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
