### PR TITLE
BUG: Separator appears in MRML node combobox menu with custom items only

### DIFF
--- a/Libs/MRML/Widgets/qMRMLNodeComboBox.cxx
+++ b/Libs/MRML/Widgets/qMRMLNodeComboBox.cxx
@@ -241,7 +241,8 @@ void qMRMLNodeComboBoxPrivate::updateActionItems(bool resetRootIndex)
   QStringList extraItems;
   if (q->mrmlScene())
     {
-    if (this->AddEnabled || this->RemoveEnabled || this->EditEnabled || this->RenameEnabled)
+    if (this->AddEnabled || this->RemoveEnabled || this->EditEnabled
+        || this->RenameEnabled || !this->UserMenuActions.empty())
       {
       extraItems.append("separator");
       }


### PR DESCRIPTION
The MRML node combobox can have extra items on the top or bottom of the node list. There are built-in extra items, such as None, Add, etc. When these are enabled, then a separator appears between the nodes and the items. However, when no built-in extra item is enabled, just custom extra items are added, then the separator did not show up.
