### PR TITLE
ENH: Update Git tag for OpenIGTLinkIF to include color image support.

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -147,7 +147,7 @@ list(APPEND Slicer_REMOTE_DEPENDENCIES jqPlot)
 
 Slicer_Remote_Add(OpenIGTLinkIF
   GIT_REPOSITORY ${git_protocol}://github.com/openigtlink/OpenIGTLinkIF.git
-  GIT_TAG 38491441f112df5a6fb6062f2cdf0a3cfcb1450b
+  GIT_TAG 24ae5443ecb633a54ab7b7b8178da53d1c5e2f74
   OPTION_NAME Slicer_BUILD_OpenIGTLinkIF
   OPTION_DEPENDS "Slicer_BUILD_QTLOADABLEMODULES;Slicer_USE_OpenIGTLink"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
Color image support has been implemented in OpenIGTLinkIF.

http://www.na-mic.org/Bug/view.php?id=3649
