### PR TITLE
ENH: Remove warning: ‘itk::DiffusionTensor3DRead<float>’ declared with g...

### DIFF
--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DRead.h
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DRead.h
@@ -32,7 +32,7 @@ namespace itk
  */
 
 template <class TData>
-class DiffusionTensor3DRead : public Object
+class ITK_ABI_EXPORT DiffusionTensor3DRead : public Object
 {
 public:
   typedef TData                                DataType;


### PR DESCRIPTION
...reater visibility than the type of its field ‘itk::DiffusionTensor3DRead<float>::m_Reader’

See comments: https://github.com/Slicer/Slicer/pull/121
Due to the fact that itkDiffusionTensor3DRead was declaring a private variable of type itkImageFileReader<DiffusionImageType>::Pointer and that this class was declared with ITK_ABI_EXPORT, we had to add ITK_ABI_EXPORT to the declaration of itkDiffusionTensor3DRead to remove the previously described warning when ResampleDTIVolume was compiled (shared object).
