### PR TITLE
BUG: Added error reporting for scene file writing

### DIFF
--- a/Base/QTCore/qSlicerCoreIOManager.cxx
+++ b/Base/QTCore/qSlicerCoreIOManager.cxx
@@ -471,6 +471,7 @@ bool qSlicerCoreIOManager::saveNodes(qSlicerIO::IOFileType fileType,
   const QList<qSlicerFileWriter*> writers = d->writers(fileType, parameters);
 
   QStringList nodes;
+  bool writeSuccess=false;
   foreach (qSlicerFileWriter* writer, writers)
     {
     writer->setMRMLScene(d->currentScene());
@@ -479,23 +480,24 @@ bool qSlicerCoreIOManager::saveNodes(qSlicerIO::IOFileType fileType,
       continue;
       }
     nodes << writer->writtenNodes();
+    writeSuccess = true;
     break;
+    }
+
+  if (!writeSuccess)
+    {
+    // no appropriate writer was found
+    return false;
     }
 
   if (nodes.count() == 0 &&
       fileType != QString("SceneFile"))
     {
+    // the writer did not report error
+    // but did not report any successfully written nodes either
     return false;
     }
 
-  //if (savedNodes)
-  //{
-  //foreach(const QString& node, nodes)
-  //{
-  //loadedNodes->AddItem(
-  //d->currentScene()->GetNodeByID(node.toLatin1()));
-  //}
-  //}
   return true;
 }
 

--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -1091,6 +1091,18 @@ bool qSlicerSaveDataDialogPrivate::saveScene()
     {
     this->LastMRMLSceneFileFormat = this->sceneFileFormat();
     }
+  else
+    {
+    QMessageBox::StandardButton answer =
+      QMessageBox::question(this, tr("Saving scene..."),
+                            tr("Cannot write scene file: %1.\n"
+                               "Do you want to ignore this error and close saving?").arg(file.absoluteFilePath()),
+                            QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+    if (answer == QMessageBox::Yes)
+      {
+      res = true;
+      }
+    }
 
   return res;
 }

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -855,7 +855,7 @@ int vtkMRMLScene::Commit(const char* url)
       {
       vtkErrorMacro("Commit: URL is not set");
       this->SetErrorCode(vtkErrorCode::GetErrorCodeFromString("CannotOpenFileError"));
-      return 1;
+      return 0;
       }
     }
 
@@ -887,7 +887,7 @@ int vtkMRMLScene::Commit(const char* url)
 #else
      this->SetErrorCode(vtkErrorCode::GetErrorCodeFromString("CannotOpenFileError"));
 #endif
-      return 1;
+      return 0;
       }
     }
 

--- a/Libs/MRML/Core/vtkMRMLSceneViewStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSceneViewStorageNode.cxx
@@ -20,6 +20,7 @@
 // VTK includes
 #include <vtkBMPReader.h>
 #include <vtkBMPWriter.h>
+#include <vtkErrorCode.h>
 #include <vtkImageData.h>
 #include <vtkJPEGReader.h>
 #include <vtkJPEGWriter.h>
@@ -27,6 +28,7 @@
 #include <vtkObjectFactory.h>
 #include <vtkPNGReader.h>
 #include <vtkPNGWriter.h>
+#include <vtkSmartPointer.h>
 #include <vtkStringArray.h>
 #include <vtkTIFFReader.h>
 #include <vtkTIFFWriter.h>
@@ -94,55 +96,45 @@ int vtkMRMLSceneViewStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
 
   int result = 1;
   vtkNew<vtkImageData> imageData;
+  vtkSmartPointer<vtkImageReader2> reader;
+
+  if ( extension == std::string(".png") )
+    {
+      reader=vtkSmartPointer<vtkPNGReader>::New();
+    }
+  else if (extension == std::string(".jpg") ||
+           extension == std::string(".jpeg"))
+    {
+    reader=vtkSmartPointer<vtkJPEGReader>::New();
+    }
+  else if (extension == std::string(".tiff"))
+    {
+    reader=vtkSmartPointer<vtkTIFFReader>::New();
+    }
+  else if (extension == std::string(".bmp"))
+    {
+    reader=vtkSmartPointer<vtkBMPReader>::New();
+    }
+  else
+    {
+    vtkDebugMacro("Cannot read scene view file '" << fullName.c_str() << "' (extension = " << extension.c_str() << ")");
+    return 0;
+    }
 
   try
     {
-    if ( extension == std::string(".png") )
+    reader->SetFileName(fullName.c_str());
+    reader->Update();
+    if (reader->GetOutput())
       {
-      vtkNew<vtkPNGReader> reader;
-      reader->SetFileName(fullName.c_str());
-      reader->Update();
-      if (reader->GetOutput())
-        {
-        vtkDebugMacro("ReadData: read file, copying output to image data");
-        imageData->DeepCopy(reader->GetOutput());
-        }
+      vtkDebugMacro("ReadData: read file, copying output to image data");
+      imageData->DeepCopy(reader->GetOutput());
       }
-    else if (extension == std::string(".jpg") ||
-             extension == std::string(".jpeg"))
+    if (reader->GetErrorCode() != vtkErrorCode::NoError)
       {
-      vtkNew<vtkJPEGReader> reader;
-      reader->SetFileName(fullName.c_str());
-      reader->Update();
-      if (reader->GetOutput())
-        {
-        imageData->DeepCopy(reader->GetOutput());
-        }
-      }
-    else if (extension == std::string(".tiff"))
-      {
-      vtkNew<vtkTIFFReader> reader;
-      reader->SetFileName(fullName.c_str());
-      reader->Update();
-      if (reader->GetOutput())
-        {
-        imageData->DeepCopy(reader->GetOutput());
-        }
-      }
-    else if (extension == std::string(".bmp"))
-      {
-      vtkNew<vtkBMPReader> reader;
-      reader->SetFileName(fullName.c_str());
-      reader->Update();
-      if (reader->GetOutput())
-        {
-        imageData->DeepCopy(reader->GetOutput());
-        }
-      }
-    else
-      {
-      vtkDebugMacro("Cannot read scene view file '" << fullName.c_str() << "' (extension = " << extension.c_str() << ")");
-      return 0;
+      vtkDebugMacro("Cannot read scene view file '" << fullName.c_str() << "' ("
+        << vtkErrorCode::GetStringFromErrorCode(reader->GetErrorCode()) << ")");
+      result = 0;
       }
     }
   catch (...)
@@ -181,83 +173,51 @@ int vtkMRMLSceneViewStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
 
   std::string extension=vtkMRMLStorageNode::GetLowercaseExtensionFromFileName(fullName);
 
-  int result = 1;
+  vtkSmartPointer<vtkImageWriter> writer;
   if (extension == ".png")
     {
-    vtkNew<vtkPNGWriter> writer;
-    writer->SetFileName(fullName.c_str());
-#if (VTK_MAJOR_VERSION <= 5)
-    writer->SetInput( sceneViewNode->GetScreenShot() );
-#else
-    writer->SetInputData( sceneViewNode->GetScreenShot() );
-#endif
-    try
-      {
-      writer->Write();
-      }
-    catch (...)
-      {
-      result = 0;
-      }
+    writer = vtkSmartPointer<vtkPNGWriter>::New();
     }
   else if (extension == ".jpg" || extension == ".jpeg")
     {
-    vtkNew<vtkJPEGWriter> writer;
-    writer->SetFileName(fullName.c_str());
-#if (VTK_MAJOR_VERSION <= 5)
-    writer->SetInput( sceneViewNode->GetScreenShot() );
-#else
-    writer->SetInputData( sceneViewNode->GetScreenShot() );
-#endif
-    try
-      {
-      writer->Write();
-      }
-    catch (...)
-      {
-      result = 0;
-      }
+    writer = vtkSmartPointer<vtkJPEGWriter>::New();
     }
   else if (extension == ".tiff")
     {
-    vtkNew<vtkTIFFWriter> writer;
-    writer->SetFileName(fullName.c_str());
-#if (VTK_MAJOR_VERSION <= 5)
-    writer->SetInput( sceneViewNode->GetScreenShot() );
-#else
-    writer->SetInputData( sceneViewNode->GetScreenShot() );
-#endif
-    try
-      {
-      writer->Write();
-      }
-    catch (...)
-      {
-      result = 0;
-      }
+    writer = vtkSmartPointer<vtkTIFFWriter>::New();
     }
   else if (extension == ".bmp")
     {
-    vtkNew<vtkBMPWriter> writer;
-    writer->SetFileName(fullName.c_str());
-#if (VTK_MAJOR_VERSION <= 5)
-    writer->SetInput( sceneViewNode->GetScreenShot() );
-#else
-    writer->SetInputData( sceneViewNode->GetScreenShot() );
-#endif
-    try
-      {
-      writer->Write();
-      }
-    catch (...)
-      {
-      result = 0;
-      }
+    writer = vtkSmartPointer<vtkBMPWriter>::New();
     }
   else
     {
-    result = 0;
     vtkErrorMacro( << "No file extension recognized: " << fullName.c_str() );
+    return 0;
+    }
+
+  int result = 1; // success by default
+
+  writer->SetFileName(fullName.c_str());
+#if (VTK_MAJOR_VERSION <= 5)
+  writer->SetInput( sceneViewNode->GetScreenShot() );
+#else
+  writer->SetInputData( sceneViewNode->GetScreenShot() );
+#endif
+  try
+    {
+    writer->Write();
+    }
+  catch (...)
+    {
+    vtkDebugMacro("Cannot write scene view file '" << fullName.c_str() << "' unknown exception occurred");
+    result = 0;
+    }
+  if (writer->GetErrorCode() != vtkErrorCode::NoError)
+    {
+    vtkDebugMacro("Cannot write scene view file '" << fullName.c_str() << "' ("
+      << vtkErrorCode::GetStringFromErrorCode(writer->GetErrorCode()) << ")");
+    result = 0;
     }
 
   if (result != 0)


### PR DESCRIPTION
The problem was that no error was reported to the user when:
- the scene file (.mrml) saving failed (e.g., because target location was a read-only directory), or
- sceneview thumbnail image saving failed

Not reporting failure of the scene saving can cause data loss and user frustration.
