### PR TITLE
ENH: Editor: paint using pixel mode if brush size is too small

### DIFF
--- a/Modules/Scripted/EditorLib/PaintEffect.py
+++ b/Modules/Scripted/EditorLib/PaintEffect.py
@@ -611,6 +611,26 @@ class PaintEffectTool(LabelEffect.LabelEffectTool):
       if br[i] > dims[i]:
         br[i] = dims[i] - 1
 
+    # If the region is smaller than a pixel then paint it using paintPixel mode,
+    # to make sure at least one pixel is filled on each click
+    maxRowDelta = 0
+    maxColumnDelta = 0
+    for i in xrange(3):
+      d = abs(tr[i] - tl[i])
+      if d > maxColumnDelta:
+        maxColumnDelta = d
+      d = abs(br[i] - bl[i])
+      if d > maxColumnDelta:
+        maxColumnDelta = d
+      d = abs(bl[i] - tl[i])
+      if d > maxRowDelta:
+        maxRowDelta = d
+      d = abs(br[i] - tr[i])
+      if d > maxRowDelta:
+        maxRowDelta = d
+    if maxRowDelta<=1 or maxColumnDelta<=1 :
+      self.paintPixel(x,y)
+      return
 
     #
     # get the layers and nodes


### PR DESCRIPTION
For volumes with anisotropic spacing the minimum brush size in the paint tool may be smaller than the pixel size. When a the brush size is smaller than the pixel size then no pixels are filled when the user clicks on the image, which is very confusing for the user.

How to reproduce the error:
- Load MRHead sample volume
- Change the Z spacing to 5mm
- Go to the Editor module, choose the paint tool
- Set the brush size to minimum
- Paint on the red slice viewer => ERROR: no pixels are filled

Implemented solution: added a check in the PaintEffect tool so that if the brush size is too small then pixels are painted using paintPixel mode.
