### PR TITLE
ENH: Improved scripted module loading error message

### DIFF
--- a/Base/QTCore/qSlicerScriptedFileWriter.cxx
+++ b/Base/QTCore/qSlicerScriptedFileWriter.cxx
@@ -157,8 +157,8 @@ bool qSlicerScriptedFileWriter::setPythonSource(const QString& newPythonSource, 
     PythonQt::self()->handleError();
     PyErr_SetString(PyExc_RuntimeError,
                     QString("qSlicerScriptedFileWriter::setPythonSource - "
-                            "Failed to load scripted pythonqt module class definition"
-                            " %1 from %2").arg(className).arg(newPythonSource).toLatin1());
+                            "Failed to load scripted file writer: "
+                            "class %1 was not found in file %2").arg(className).arg(newPythonSource).toLatin1());
     return false;
     }
 

--- a/Base/QTGUI/qSlicerScriptedLoadableModule.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModule.cxx
@@ -187,8 +187,8 @@ bool qSlicerScriptedLoadableModule::setPythonSource(const QString& newPythonSour
     PythonQt::self()->handleError();
     PyErr_SetString(PyExc_RuntimeError,
                     QString("qSlicerScriptedLoadableModule::setPythonSource - "
-                            "Failed to load scripted pythonqt module class definition"
-                            " %1 from %2").arg(className).arg(newPythonSource).toLatin1());
+                            "Failed to load scripted loadable module: "
+                            "class %1 was not found in file %2").arg(className).arg(newPythonSource).toLatin1());
     PythonQt::self()->handleError();
     return false;
     }

--- a/Base/QTGUI/qSlicerScriptedLoadableModuleWidget.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModuleWidget.cxx
@@ -172,8 +172,8 @@ bool qSlicerScriptedLoadableModuleWidget::setPythonSource(const QString& newPyth
     PythonQt::self()->handleError();
     PyErr_SetString(PyExc_RuntimeError,
                     QString("qSlicerScriptedLoadableModuleWidget::setPythonSource - "
-                            "Failed to load scripted pythonqt module class definition"
-                            " %1 from %2").arg(classNameToLoad).arg(newPythonSource).toLatin1());
+                            "Failed to load scripted loadable module widget: "
+                            "class %1 was not found in %2").arg(classNameToLoad).arg(newPythonSource).toLatin1());
     PythonQt::self()->handleError();
     return false;
     }


### PR DESCRIPTION
It happened multiple times in our group that a developer spent a lot of time trying to find errors in a scripted module, simplify the class, make it more similar to the template, etc. to find what can be wrong in the class because "Failed to load scripted pythonqt module class definition" error was reported. Then it turned out that the module class is perfect, only the name does not match the filename.

Implemented fix: changed the error message to "class ... not found in file ..." to make it clear that the problem is not in implementation of the class but in the name.
