### PR TITLE
BUG: Fixed DICOM browser persistence

### DIFF
--- a/Modules/Scripted/DICOM/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOM/DICOMLib/DICOMWidgets.py
@@ -481,7 +481,8 @@ class DICOMDetailsPopup(object):
           slicer.app.processEvents()
     self.progress.close()
     self.progress = None
-    self.close()
+    if not self.setBrowserPersistence:
+      self.close()
 
 class DICOMPluginSelector(object):
   """Implement the Qt code for a table of


### PR DESCRIPTION
If the DICOM browser persistent option is enabled (usually when the DICOM browser is displayed on a second monitor) then the browser should be kept open when an image is loaded or the user opens another module.
The persistent flag was observed almost everywhere where it was needed, except at the end of the image loading step.
