### PR TITLE
ENH: Allow users to acknowledge all DICOM loading errors with a single click

### DIFF
--- a/Modules/Scripted/DICOM/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOM/DICOMLib/DICOMWidgets.py
@@ -463,6 +463,7 @@ class DICOMDetailsPopup(object):
     self.progress.setValue(0)
     self.progress.setMaximum(loadableCount)
     step = 0
+    loadingResult = ''
     for plugin in self.loadablesByPlugin:
       for loadable in self.loadablesByPlugin[plugin]:
         if self.progress.wasCanceled:
@@ -474,13 +475,14 @@ class DICOMDetailsPopup(object):
           self.progress.labelText = '\nLoading %s' % loadable.name
           slicer.app.processEvents()
           if not plugin.load(loadable):
-            qt.QMessageBox.warning(slicer.util.mainWindow(),
-                'Load', 'Could not load: %s as a %s' % (loadable.name,plugin.loadType))
+            loadingResult = '%s\nCould not load: %s as a %s' % (loadingResult,loadable.name,plugin.loadType)
           step += 1
           self.progress.setValue(step)
           slicer.app.processEvents()
     self.progress.close()
     self.progress = None
+    if loadingResult:
+      qt.QMessageBox.warning(slicer.util.mainWindow(), 'DICOM loading', loadingResult)
     self.close()
 
 class DICOMPluginSelector(object):


### PR DESCRIPTION
Problem: Each DICOM loading error is displayed in a separate popup, which requires the user to click as many times as many series failed to load. In some cases there are a large number of failures (for example, experimental MRI sequences), which makes loading of a complete study very frustrating (need to click 30 times, waiting several seconds between each).

Solution: Changed the error reporting to collect all errors and show it to the user at the end of the loading in a single error popup.
