### PR TITLE
ENH: revert the default value for the number of iterations

### DIFF
--- a/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.xml
+++ b/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.xml
@@ -76,7 +76,7 @@
       <longflag>iterations</longflag>
       <label>Number of iterations</label>
       <description><![CDATA[Maximum number of iterations at each level of resolution. Larger values will increase execution time, but may lead to better results.]]></description>
-      <default>500,400,300</default>
+      <default>50,40,30</default>
     </integer-vector>
     <float>
       <name>convergenceThreshold</name>


### PR DESCRIPTION
50,40,30 is consistent with the number of iterations used since
the module was introduced in Slicer3
