### PR TITLE
ENH: Added mouse cursor position to vtkMRMLCrosshairNode.

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager.cxx
@@ -685,13 +685,15 @@ void vtkMRMLCrosshairDisplayableManager::OnInteractorStyleEvent(int eventid)
 
   this->Superclass::OnInteractorStyleEvent(eventid);
 
-  if (this->Internal->CrosshairNode && this->Internal->CrosshairNode->GetCrosshairMode() != vtkMRMLCrosshairNode::NoCrosshair)
+  if (this->Internal->CrosshairNode)
     {
     switch (eventid)
       {
       case vtkCommand::LeaveEvent:
+        this->Internal->CrosshairNode->SetCursorPositionInvalid();
         // If we are not Navigating, reposition the crosshair to the center
-        if (this->Internal->CrosshairNode->GetNavigation() == 0)
+        if (this->Internal->CrosshairNode->GetCrosshairMode() != vtkMRMLCrosshairNode::NoCrosshair
+            && this->Internal->CrosshairNode->GetNavigation() == 0)
           {
           double xyz[3], ras[3];
           vtkRenderer *renderer
@@ -704,10 +706,23 @@ void vtkMRMLCrosshairDisplayableManager::OnInteractorStyleEvent(int eventid)
           this->Internal->CrosshairNode->SetCrosshairRAS(ras[0], ras[1],ras[2]);
           }
         break;
-
+      // When we switch to the Slicer window and the mouse is already over a view
+      // then only OnInteractorStyleEvent is called with vtkCommand::EnterEvent,
+      // (OnInteractorEvent is not called) therefore we need to handle EnterEvent here
+      case vtkCommand::EnterEvent:
+          {
+          // On a mouse move, determine which lightbox is under the mouse
+          // and the RAS position of the mouse
+          int *pos = this->GetInteractor()->GetEventPosition();
+          double xyz[3];
+          this->ConvertDeviceToXYZ(pos[0], pos[1], xyz);
+          this->Internal->CrosshairNode->SetCursorPositionXYZ(xyz, this->GetMRMLSliceNode());
+          }
+        break;
       case vtkCommand::LeftButtonReleaseEvent:
         // Button release is only meaningful in navigation mode
-        if (this->Internal->CrosshairNode->GetNavigation())
+        if (this->Internal->CrosshairNode->GetCrosshairMode() != vtkMRMLCrosshairNode::NoCrosshair
+            && this->Internal->CrosshairNode->GetNavigation())
           {
           this->Internal->PickState = vtkInternal::NoPick;
           this->Internal->ActionState = vtkInternal::NoAction;
@@ -731,14 +746,15 @@ void vtkMRMLCrosshairDisplayableManager::OnInteractorEvent(int eventid)
 
   this->Superclass::OnInteractorEvent(eventid);
 
-  if (this->Internal->CrosshairNode && this->Internal->CrosshairNode->GetCrosshairMode() != vtkMRMLCrosshairNode::NoCrosshair)
+  if (this->Internal->CrosshairNode)
     {
     bool renderNeeded = false;
     switch (eventid)
       {
       case vtkCommand::LeftButtonPressEvent:
         // Button press is only meaningful in navigation mode
-        if (this->Internal->CrosshairNode->GetNavigation())
+        if (this->Internal->CrosshairNode->GetCrosshairMode() != vtkMRMLCrosshairNode::NoCrosshair
+            && this->Internal->CrosshairNode->GetNavigation())
           {
           // check whether we are close enough to navigate
           if (this->Internal->PickState == vtkInternal::Over)
@@ -751,21 +767,27 @@ void vtkMRMLCrosshairDisplayableManager::OnInteractorEvent(int eventid)
             }
           }
         break;
-
+      case vtkCommand::LeaveEvent:
+        this->Internal->CrosshairNode->SetCursorPositionInvalid();
+        break;
       case vtkCommand::MouseMoveEvent:
+      case vtkCommand::EnterEvent:
         // On a mouse move, determine which lightbox is under the mouse
         // and the RAS position of the mouse
-        int *pos =  this->GetInteractor()->GetEventPosition();
+        int *pos = this->GetInteractor()->GetEventPosition();
 
         double xyz[3];
         this->ConvertDeviceToXYZ(pos[0], pos[1], xyz);
+
+        this->Internal->CrosshairNode->SetCursorPositionXYZ(xyz, this->GetMRMLSliceNode());
 
         double ras[3];
         this->ConvertXYZToRAS(xyz, ras);
 
         // Navigation mode and Cross-referencing mode handle the
         // information differently
-        if (this->Internal->CrosshairNode->GetNavigation())
+        if (this->Internal->CrosshairNode->GetCrosshairMode() != vtkMRMLCrosshairNode::NoCrosshair
+            && this->Internal->CrosshairNode->GetNavigation())
           {
           // Navigation mode.
           switch (this->Internal->ActionState)
@@ -840,7 +862,7 @@ void vtkMRMLCrosshairDisplayableManager::OnInteractorEvent(int eventid)
               break;
             }
           }
-        else
+        else if (this->Internal->CrosshairNode->GetCrosshairMode() != vtkMRMLCrosshairNode::NoCrosshair)
           {
           // Cross-referencing mode. Set the new position on the crosshair
           // modifying the CrosshairRAS will trigger a render
@@ -914,5 +936,3 @@ void vtkMRMLCrosshairDisplayableManager::OnMRMLSliceNodeModifiedEvent()
       this->RequestRender();
     }
 }
-
-

--- a/Modules/Loadable/Transforms/Resources/UI/qSlicerTransformsModuleWidget.ui
+++ b/Modules/Loadable/Transforms/Resources/UI/qSlicerTransformsModuleWidget.ui
@@ -711,5 +711,21 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>qSlicerTransformsModuleWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>TransformInfoWidget</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>195</x>
+     <y>611</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>195</x>
+     <y>59</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
 </ui>

--- a/Modules/Loadable/Transforms/Widgets/Resources/UI/qMRMLTransformInfoWidget.ui
+++ b/Modules/Loadable/Transforms/Widgets/Resources/UI/qMRMLTransformInfoWidget.ui
@@ -88,6 +88,17 @@
      </item>
     </layout>
    </item>
+    <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+          <widget class="QLabel" name="ViewerDisplacementVectorRAS">
+            <property name="text">
+              <string>ViewerRAS</string>
+            </property>
+          </widget>
+        </item>
+      </layout>
+    </item>
   </layout>
  </widget>
  <resources/>

--- a/Modules/Loadable/Transforms/Widgets/qMRMLTransformInfoWidget.cxx
+++ b/Modules/Loadable/Transforms/Widgets/qMRMLTransformInfoWidget.cxx
@@ -26,7 +26,14 @@
 #include "ui_qMRMLTransformInfoWidget.h"
 
 // MRML includes
+#include <vtkMRMLCrosshairNode.h>
 #include <vtkMRMLTransformNode.h>
+#include <vtkMRMLScene.h>
+
+// VTK includes
+#include <vtkMath.h>
+#include <vtkTransform.h>
+#include <vtkWeakPointer.h>
 
 //------------------------------------------------------------------------------
 class qMRMLTransformInfoWidgetPrivate: public Ui_qMRMLTransformInfoWidget
@@ -40,14 +47,21 @@ public:
   qMRMLTransformInfoWidgetPrivate(qMRMLTransformInfoWidget& object);
   void init();
 
-  vtkMRMLTransformNode* MRMLTransformNode;
+  void setAndObserveCrosshairNode();
+
+  vtkWeakPointer<vtkMRMLScene> MRMLScene;
+  vtkWeakPointer<vtkMRMLTransformNode> TransformNode;
+  vtkWeakPointer<vtkMRMLCrosshairNode> CrosshairNode;
 };
 
 //------------------------------------------------------------------------------
-qMRMLTransformInfoWidgetPrivate::qMRMLTransformInfoWidgetPrivate(qMRMLTransformInfoWidget& object)
+qMRMLTransformInfoWidgetPrivate
+::qMRMLTransformInfoWidgetPrivate(qMRMLTransformInfoWidget& object)
   : q_ptr(&object)
 {
-  this->MRMLTransformNode = 0;
+  this->TransformNode = 0;
+  this->CrosshairNode = 0;
+  this->MRMLScene = 0;
 }
 
 //------------------------------------------------------------------------------
@@ -55,9 +69,27 @@ void qMRMLTransformInfoWidgetPrivate::init()
 {
   Q_Q(qMRMLTransformInfoWidget);
   this->setupUi(q);
-  q->setEnabled(this->MRMLTransformNode != 0);
+  q->setEnabled(this->TransformNode.GetPointer() != 0);
   this->TransformToParentInfoTextBrowser->setTextInteractionFlags(Qt::TextSelectableByMouse);
   this->TransformFromParentInfoTextBrowser->setTextInteractionFlags(Qt::TextSelectableByMouse);
+}
+
+// --------------------------------------------------------------------------
+void qMRMLTransformInfoWidgetPrivate::setAndObserveCrosshairNode()
+{
+  Q_Q(qMRMLTransformInfoWidget);
+
+  vtkMRMLCrosshairNode* crosshairNode = 0;
+  if (this->MRMLScene.GetPointer())
+    {
+    crosshairNode = vtkMRMLCrosshairNode::SafeDownCast(this->MRMLScene->GetNthNodeByClass(0, "vtkMRMLCrosshairNode"));
+    }
+
+  q->qvtkReconnect(this->CrosshairNode.GetPointer(), crosshairNode,
+    vtkMRMLCrosshairNode::CursorPositionModifiedEvent,
+    q, SLOT(updateTransformVectorDisplayFromMRML()));
+  this->CrosshairNode = crosshairNode;
+  q->updateTransformVectorDisplayFromMRML();
 }
 
 //------------------------------------------------------------------------------
@@ -75,10 +107,25 @@ qMRMLTransformInfoWidget::~qMRMLTransformInfoWidget()
 }
 
 //------------------------------------------------------------------------------
+void qMRMLTransformInfoWidget::processEvent(
+  vtkObject* caller, void* callData, unsigned long eventId, void* clientData)
+{
+  Q_D(qMRMLTransformInfoWidget);
+  Q_UNUSED(caller);
+  Q_UNUSED(callData);
+  Q_UNUSED(clientData);
+
+  if (eventId == vtkMRMLCrosshairNode::CursorPositionModifiedEvent)
+    {
+    this->updateTransformVectorDisplayFromMRML();
+    }
+}
+
+//------------------------------------------------------------------------------
 vtkMRMLTransformNode* qMRMLTransformInfoWidget::mrmlTransformNode()const
 {
   Q_D(const qMRMLTransformInfoWidget);
-  return d->MRMLTransformNode;
+  return d->TransformNode.GetPointer();
 }
 
 //------------------------------------------------------------------------------
@@ -87,13 +134,36 @@ void qMRMLTransformInfoWidget::setMRMLTransformNode(vtkMRMLNode* node)
   this->setMRMLTransformNode(vtkMRMLTransformNode::SafeDownCast(node));
 }
 
+// --------------------------------------------------------------------------
+vtkMRMLScene* qMRMLTransformInfoWidget::mrmlScene()const
+{
+  Q_D(const qMRMLTransformInfoWidget);
+  return d->MRMLScene.GetPointer();
+}
+
+// --------------------------------------------------------------------------
+void qMRMLTransformInfoWidget::setMRMLScene(vtkMRMLScene* scene)
+{
+  Q_D(qMRMLTransformInfoWidget);
+
+  if (this->mrmlScene() == scene)
+    {
+    return;
+    }
+
+  d->MRMLScene = scene;
+  d->setAndObserveCrosshairNode();
+}
+
 //------------------------------------------------------------------------------
 void qMRMLTransformInfoWidget::setMRMLTransformNode(vtkMRMLTransformNode* transformNode)
 {
   Q_D(qMRMLTransformInfoWidget);
-  qvtkReconnect(d->MRMLTransformNode, transformNode, vtkCommand::ModifiedEvent,
+
+  qvtkReconnect(d->TransformNode.GetPointer(), transformNode, vtkCommand::ModifiedEvent,
                 this, SLOT(updateWidgetFromMRML()));
-  d->MRMLTransformNode = transformNode;
+  d->TransformNode = transformNode;
+
   this->updateWidgetFromMRML();
 }
 
@@ -101,16 +171,50 @@ void qMRMLTransformInfoWidget::setMRMLTransformNode(vtkMRMLTransformNode* transf
 void qMRMLTransformInfoWidget::updateWidgetFromMRML()
 {
   Q_D(qMRMLTransformInfoWidget);
-  if (d->MRMLTransformNode)
+  if (d->TransformNode.GetPointer())
     {
-    d->TransformToParentInfoTextBrowser->setText(d->MRMLTransformNode->GetTransformToParentInfo());
-    d->TransformFromParentInfoTextBrowser->setText(d->MRMLTransformNode->GetTransformFromParentInfo());
+    d->TransformToParentInfoTextBrowser->setText(d->TransformNode->GetTransformToParentInfo());
+    d->TransformFromParentInfoTextBrowser->setText(d->TransformNode->GetTransformFromParentInfo());
     }
   else
     {
-    d->TransformToParentInfoTextBrowser->setText("");
-    d->TransformFromParentInfoTextBrowser->setText("");
+    d->TransformToParentInfoTextBrowser->clear();
+    d->TransformFromParentInfoTextBrowser->clear();
     }
 
-  this->setEnabled(d->MRMLTransformNode != 0);
+  updateTransformVectorDisplayFromMRML();
+
+  this->setEnabled(d->TransformNode.GetPointer() != 0);
+}
+
+//------------------------------------------------------------------------------
+void qMRMLTransformInfoWidget::updateTransformVectorDisplayFromMRML()
+{
+  Q_D(qMRMLTransformInfoWidget);
+  if (d->TransformNode.GetPointer() && d->CrosshairNode.GetPointer())
+    {
+    double ras[3]={0};
+    bool validPosition = d->CrosshairNode->GetCursorPositionRAS(ras);
+    if (validPosition)
+      {
+      // Get the displacement vector
+      vtkAbstractTransform* transformToParent = d->TransformNode->GetTransformToParent();
+      double* rasDisplaced = transformToParent->TransformDoublePoint(ras[0], ras[1], ras[2]);
+
+      // Verify if the transform is invertible at the current position
+      vtkAbstractTransform* transformFromParent = d->TransformNode->GetTransformFromParent();
+      double* rasDisplacedTransformedBack = transformFromParent->TransformDoublePoint(rasDisplaced[0], rasDisplaced[1], rasDisplaced[2]);
+      static double INVERSE_COMPUTATION_ALLOWED_SQUARED_ERROR=0.1;
+      bool inverseAccurate = vtkMath::Distance2BetweenPoints(ras,rasDisplacedTransformedBack)<INVERSE_COMPUTATION_ALLOWED_SQUARED_ERROR;
+
+      d->ViewerDisplacementVectorRAS->setText(QString("Displacement vector  RAS: (%1, %2, %3)%4").
+        arg(rasDisplaced[0] - ras[0], /* fieldWidth= */ 0, /* format = */ 'f', /* precision= */ 1).
+        arg(rasDisplaced[1] - ras[1], /* fieldWidth= */ 0, /* format = */ 'f', /* precision= */ 1).
+        arg(rasDisplaced[2] - ras[2], /* fieldWidth= */ 0, /* format = */ 'f', /* precision= */ 1).
+        arg(inverseAccurate?"":"   Warning: inverse is inaccurate!") );
+      return;
+      }
+    }
+  // transform value is not available, so let's clear the display
+  d->ViewerDisplacementVectorRAS->clear();
 }

--- a/Modules/Loadable/Transforms/Widgets/qMRMLTransformInfoWidget.h
+++ b/Modules/Loadable/Transforms/Widgets/qMRMLTransformInfoWidget.h
@@ -52,18 +52,26 @@ public:
 
   vtkMRMLTransformNode* mrmlTransformNode()const;
 
+  vtkMRMLScene* mrmlScene()const;
+
 public slots:
 
   /// Set the MRML node of interest
   /// Note that setting transformNode to 0 will disable the widget
   void setMRMLTransformNode(vtkMRMLTransformNode* transformNode);
 
+  void setMRMLScene(vtkMRMLScene* scene);
+
   /// Utility function that calls setMRMLTransformNode(vtkMRMLTransformNode* transformNode)
   /// It's useful to connect to vtkMRMLNode* signals
   void setMRMLTransformNode(vtkMRMLNode* node);
 
+  /// Process event function
+  void processEvent(vtkObject* sender, void* callData, unsigned long eventId, void* clientData);
+
 protected slots:
   void updateWidgetFromMRML();
+  void updateTransformVectorDisplayFromMRML();
 
 protected:
   QScopedPointer<qMRMLTransformInfoWidgetPrivate> d_ptr;


### PR DESCRIPTION
Now cursor (now only mouse position in 2D Slice view, but later also other pointing devices can be supported) position can be obtained by observing the vtkMRMLCrosshairNode singleton node.

The feature is used in:
- DataProbe window
- Transform info window (showing the transform displacement vector value at the current mouse position in real-time)

After the integration into the Slicer core is done, it will be also used in MultiVolume, Multidimensional data for live 3D graphing.
