### PR TITLE
ENH: add python access to scene view nodes

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLSceneViewNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneViewNodeTest1.cxx
@@ -16,6 +16,7 @@
 #include "vtkMRMLSceneViewNode.h"
 
 // VTK includes
+#include <vtkCollection.h>
 #include <vtkImageData.h>
 #include <vtkNew.h>
 
@@ -31,6 +32,12 @@ int vtkMRMLSceneViewNodeTest1(int , char * [] )
   // test with null scene
   node1->StoreScene();
   node1->SetAbsentStorageFileNames();
+  vtkCollection *col = node1->GetNodesByClass(NULL);
+  if (col != NULL)
+    {
+    std::cout << "Failed to get empty collection" << std::endl;
+    return EXIT_FAILURE;
+    }
 
   // make a scene and test again
   vtkNew<vtkMRMLScene> scene;
@@ -57,6 +64,15 @@ int vtkMRMLSceneViewNodeTest1(int , char * [] )
   imageData = node1->GetScreenShot();
 
   TEST_SET_GET_INT_RANGE(node1.GetPointer(), ScreenShotType, 0, 4);
+
+  col = node1->GetNodesByClass("vtkMRMLNode");
+  if (!col)
+    {
+    std::cerr << "Failed to get mrml nodes from scene view snapshot scene" << std::endl;
+    return EXIT_FAILURE;
+    }
+  col->RemoveAllItems();
+  col->Delete();
 
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
@@ -637,7 +637,21 @@ void vtkMRMLSceneViewNode::SetScreenShotType(int newScreenShotType)
 //----------------------------------------------------------------------------
 int vtkMRMLSceneViewNode::GetNodesByClass(const char *className, std::vector<vtkMRMLNode *> &nodes)
 {
+  if (!this->SnapshotScene)
+    {
+    return 0;
+    }
   return this->SnapshotScene->GetNodesByClass(className, nodes);
+}
+
+//------------------------------------------------------------------------------
+vtkCollection* vtkMRMLSceneViewNode::GetNodesByClass(const char *className)
+{
+  if (!this->SnapshotScene)
+    {
+    return NULL;
+    }
+  return this->SnapshotScene->GetNodesByClass(className);
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLSceneViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLSceneViewNode.h
@@ -19,6 +19,7 @@
 
 // VTK includes
 #include <vtkStdString.h>
+class vtkCollection;
 class vtkImageData;
 
 class vtkMRMLStorageNode;
@@ -102,8 +103,15 @@ class VTK_MRML_EXPORT vtkMRMLSceneViewNode : public vtkMRMLStorableNode
   /// Create default storage node or NULL if does not have one
   virtual vtkMRMLStorageNode* CreateDefaultStorageNode();
 
- /// Get vector of nodes of a specified class in the scene
+  /// Get vector of nodes of a specified class in the scene.
+  /// Returns 0 on failure, number of nodes on success.
+  /// \sa vtkMRMLScene;:GetNodesByClass
   int GetNodesByClass(const char *className, std::vector<vtkMRMLNode *> &nodes);
+  /// Get a collection of nodes of a specified class (for python access)
+  /// You are responsible for deleting the returned collection.
+  /// Returns NULL on failure.
+  /// \sa vtkMRMLScene::GetNodesByClass
+  vtkCollection* GetNodesByClass(const char *className);
 
   /// check if a node should be included in the save/restore cycle. Returns
   /// false if it's a scene view node, scene view storage node, scene view


### PR DESCRIPTION
Add a wrapper to the scene's GetNodesByClass that
returns a vtkCollection.
Added testing.

To support the MosaicViewer project.
