### PR TITLE
ENH: Update OpenIGTLink from 1.10.4 to 1.10.10 to include bug fixes.

### DIFF
--- a/SuperBuild/External_OpenIGTLink.cmake
+++ b/SuperBuild/External_OpenIGTLink.cmake
@@ -28,7 +28,7 @@ if(NOT DEFINED OpenIGTLink_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${git_protocol}://github.com/openigtlink/OpenIGTLink.git"
-    GIT_TAG "3ac531115f55e74265e7de7ff508312dbfb16695"
+    GIT_TAG "849b434b4b45a28e3955adf4ba1f3ececd51581e"
     SOURCE_DIR OpenIGTLink
     BINARY_DIR OpenIGTLink-build
     CMAKE_CACHE_ARGS


### PR DESCRIPTION
```
$ git shortlog 3ac5311..849b434 --no-merges
Andras Lasso (1):
      Add the MSG_NOSIGNAL flag to socket send calls to prevent application crash on disconnect on linux systems

Gergely Zombori (1):
      Bug #1912 - Merged the changes and enhancements from upstream into 'master'

Isaiah Norton (1):
      BUG: use shutdown() instead of close() for sockets

Junichi Tokuda (7):
      BUG: Address issue #29: copy igtl_win32hearder.h to the install directory.
      ENH: Update patch number.
      STYLE: Update patch number.
      COMP: Fix compilation error due to lack of MSG_NOSIGNAL option in send() in Mac OS X. For Mac OS X, call setsockopt() with SO_NOSIGPIPE instead.
      STYLE: Update revision number.
      BUG: Set timestamp zero, when no timestamp object is registered to image meta message.
      STYLE: Update patch number

Laurent Chauvin (1):
      BUG: Initialize ImageMessage matrix to identity (issue #39)

Matt Clarkson (3):
      #44: Put nanosleep in loop to ensure sleep is for the correct time.
      #49: Avoid crash on division by zero, which should never happen
      #50: Convenience methods to set/get igtl_image matrix from 4x4 array of floats

z0022myy (1):
      BUG: Intializing pointer should not be in a loop
```
