### PR TITLE
Add the capability to pass derived items from the plugin

### DIFF
--- a/Modules/Scripted/DICOM/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOM/DICOMLib/DICOMWidgets.py
@@ -480,8 +480,8 @@ class DICOMDetailsPopup(object):
           self.progress.setValue(step)
           slicer.app.processEvents()
         try:
-          indexer = ctk.ctkDICOMIndexer()
           for derivedItem in loadable.derivedItems:
+            indexer = ctk.ctkDICOMIndexer()
             self.progress.labelText = '\nIndexing %s' % derivedItem
             slicer.app.processEvent()
             indexer.addFile(slicer.dicomDatabase, derivedItem)


### PR DESCRIPTION
Files corresponding to derived DICOM objects are saved as a list in the attribute of loadable, and are added to the Slicer DICOM database upon load completion. This topic has been coordinated with @pieper.
