### PR TITLE
BUG: Fixed issue of DICOM browser not closed after loading a volume

### DIFF
--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -160,9 +160,6 @@ class DICOMWidget:
     self.testingServer = None
     self.dicomBrowser = None
 
-    # options for browser
-    self.browserPersistent = False
-
     # TODO: are these wrapped so we can avoid magic numbers?
     self.dicomModelUIDRole = 32
     self.dicomModelTypeRole = self.dicomModelUIDRole + 1
@@ -194,7 +191,7 @@ class DICOMWidget:
     self.detailsPopup.open()
 
   def exit(self):
-    if not self.browserPersistent:
+    if not self.detailsPopup.browserPersistent:
       self.detailsPopup.close()
 
   def updateGUIFromMRML(self, caller, event):
@@ -264,7 +261,7 @@ class DICOMWidget:
     self.dicomBrowser = ctk.ctkDICOMBrowser()
     DICOM.setDatabasePrecacheTags(self.dicomBrowser)
 
-    self.detailsPopup = DICOMLib.DICOMDetailsPopup(self.dicomBrowser,setBrowserPersistence=self.setBrowserPersistence)
+    self.detailsPopup = DICOMLib.DICOMDetailsPopup(self.dicomBrowser)
 
     self.tables = self.detailsPopup.tables
 
@@ -486,10 +483,6 @@ class DICOMWidget:
       files += slicer.dicomDatabase.filesForSeries(serie)
     sendDialog = DICOMLib.DICOMSendDialog(files)
     sendDialog.open()
-
-  def setBrowserPersistence(self,onOff):
-    self.detailsPopup.setModality(not onOff)
-    self.browserPersistent = onOff
 
   def onToggleListener(self):
     if hasattr(slicer, 'dicomListener'):

--- a/Modules/Scripted/DICOM/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOM/DICOMLib/DICOMWidgets.py
@@ -28,11 +28,14 @@ class DICOMDetailsPopup(object):
   This is a helper used in the DICOMWidget class.
   """
 
-  def __init__(self,dicomBrowser,setBrowserPersistence=None):
+  def __init__(self,dicomBrowser):
     self.dicomBrowser = dicomBrowser
-    self.setBrowserPersistence = setBrowserPersistence
     self.popupGeometry = qt.QRect()
     settings = qt.QSettings()
+
+    self.browserPersistent = False
+    if settings.contains('DICOM/BrowserPersistent'):
+      self.browserPersistent = settings.value('DICOM/BrowserPersistent').lower() == 'true'
 
     self.advancedViewCheckState = False
 
@@ -93,6 +96,8 @@ class DICOMDetailsPopup(object):
       self.dock.setWidget(self.window)
     else:
       raise "Unknown widget type - should be dialog, window, dock or popup"
+
+    self.setModality(not self.browserPersistent)
 
     self.window.setWindowTitle('DICOM Browser')
 
@@ -203,11 +208,11 @@ class DICOMDetailsPopup(object):
       self.horizontalViewCheckBox.checked = True
     self.horizontalViewCheckBox.connect('stateChanged(int)', self.onHorizontalViewCheckBox)
 
-    if self.setBrowserPersistence:
-      self.browserPersistentButton = qt.QCheckBox('Browser Persistent')
-      self.browserPersistentButton.toolTip = 'When enabled, DICOM Broswer remains open and usable after leaving DICOM module'
-      self.actionButtonLayout.addWidget(self.browserPersistentButton)
-      self.browserPersistentButton.connect('stateChanged(int)', self.setBrowserPersistence)
+    self.browserPersistentButton = qt.QCheckBox('Browser Persistent')
+    self.browserPersistentButton.toolTip = 'When enabled, DICOM Browser remains open after loading data or switching to another module'
+    self.browserPersistentButton.checked = self.browserPersistent
+    self.actionButtonLayout.addWidget(self.browserPersistentButton)
+    self.browserPersistentButton.connect('stateChanged(int)', self.setBrowserPersistence)
 
 
     if self.advancedViewCheckState == True:
@@ -255,6 +260,13 @@ class DICOMDetailsPopup(object):
         arrayIndex += 1
 
     settings.endArray()
+
+  def setBrowserPersistence(self,state):
+    self.browserPersistent = state
+    self.setModality(not self.browserPersistent)
+    settings = qt.QSettings()
+    browserPersistentSettingString = 'true' if self.browserPersistent else 'false'
+    settings.setValue('DICOM/BrowserPersistent', browserPersistentSettingString)
 
   def onSettingsButton(self, status):
     print 'toggled'
@@ -483,7 +495,7 @@ class DICOMDetailsPopup(object):
     self.progress = None
     if loadingResult:
       qt.QMessageBox.warning(slicer.util.mainWindow(), 'DICOM loading', loadingResult)
-    if not self.setBrowserPersistence:
+    if not self.browserPersistent:
       self.close()
 
 class DICOMPluginSelector(object):


### PR DESCRIPTION
Browser was not closed after loading a volume even if "Persistent" checkbox was unchecked.

Also added a settings (DICOM/BrowserPersistent) to remember the checkbox setting.
