### PR TITLE
BUG: Fixed crash when cloned volume does not have display node

### DIFF
--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -975,8 +975,11 @@ CloneVolume (vtkMRMLScene *scene, vtkMRMLVolumeNode *volumeNode, const char *nam
     {
     clonedDisplayNode = vtkSmartPointer<vtkMRMLScalarVolumeDisplayNode>::New();
     }
-  clonedDisplayNode->CopyWithScene(volumeNode->GetDisplayNode());
-  scene->AddNode(clonedDisplayNode);
+  if ( volumeNode->GetDisplayNode() )
+    {
+    clonedDisplayNode->CopyWithScene(volumeNode->GetDisplayNode());
+    scene->AddNode(clonedDisplayNode);
+    }
 
   // clone the volume node
   vtkNew<vtkMRMLScalarVolumeNode> clonedVolumeNode;
@@ -984,7 +987,10 @@ CloneVolume (vtkMRMLScene *scene, vtkMRMLVolumeNode *volumeNode, const char *nam
   clonedVolumeNode->SetAndObserveStorageNodeID(NULL);
   std::string uname = scene->GetUniqueNameByString(name);
   clonedVolumeNode->SetName(uname.c_str());
-  clonedVolumeNode->SetAndObserveDisplayNodeID(clonedDisplayNode->GetID());
+  if ( volumeNode->GetDisplayNode() )
+    {
+    clonedVolumeNode->SetAndObserveDisplayNodeID(clonedDisplayNode->GetID());
+    }
 
   // copy over the volume's data
  // Kilian: VTK crashes when volumeNode->GetImageData() = NULL


### PR DESCRIPTION
We had a crash when cloning a volume node with no display node. Is this a good fix? Or should we create a default display node? Or refuse cloning without a display node?
