### PR TITLE
ENH: Added the enhanced scalarbar actor class based on VTK6.

### DIFF
--- a/Modules/Loadable/Colors/CMakeLists.txt
+++ b/Modules/Loadable/Colors/CMakeLists.txt
@@ -6,6 +6,7 @@ set(MODULE_TITLE "${MODULE_NAME}")
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
 #-----------------------------------------------------------------------------
+add_subdirectory(VTKWidgets)
 add_subdirectory(Logic)
 
 #-----------------------------------------------------------------------------
@@ -37,6 +38,7 @@ set(MODULE_UI_SRCS
   )
 
 set(MODULE_TARGET_LIBRARIES
+  vtkSlicer${MODULE_NAME}ModuleVTKWidgets
   vtkSlicer${MODULE_NAME}ModuleLogic
   )
 

--- a/Modules/Loadable/Colors/Resources/UI/qSlicerColorsModuleWidget.ui
+++ b/Modules/Loadable/Colors/Resources/UI/qSlicerColorsModuleWidget.ui
@@ -205,6 +205,19 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
+       <widget class="QCheckBox" name="UseColorNameAsLabelCheckBox">
+        <property name="toolTip">
+         <string>Toggle between using the names of color table colors and the scalar values for the labels in the scalar bar widget.</string>
+        </property>
+        <property name="text">
+         <string>Use color names for labels</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+       </property>
+       </widget>
+      </item>
+      <item>
        <widget class="ctkVTKScalarBarWidget" name="VTKScalarBar"/>
       </item>
      </layout>

--- a/Modules/Loadable/Colors/Testing/CMakeLists.txt
+++ b/Modules/Loadable/Colors/Testing/CMakeLists.txt
@@ -1,1 +1,4 @@
 add_subdirectory(Cxx)
+if(Slicer_USE_PYTHONQT)
+  add_subdirectory(Python)
+endif()

--- a/Modules/Loadable/Colors/Testing/Python/CMakeLists.txt
+++ b/Modules/Loadable/Colors/Testing/Python/CMakeLists.txt
@@ -1,0 +1,12 @@
+include(SlicerMacroBuildScriptedModule)
+set(COLORS_PYTHON_RESOURCES
+  )
+
+# Test vtkSlicerScalarBarActor class
+slicerMacroBuildScriptedModule(
+  NAME ColorsScalarBarSelfTest
+  SCRIPTS ColorsScalarBarSelfTest.py
+  RESOURCES ${MARKUPS_PYTHON_RESOURCES}
+  )
+slicer_add_python_unittest(SCRIPT ColorsScalarBarSelfTest.py
+                           SLICER_ARGS --disable-cli-modules)

--- a/Modules/Loadable/Colors/Testing/Python/ColorsScalarBarSelfTest.py
+++ b/Modules/Loadable/Colors/Testing/Python/ColorsScalarBarSelfTest.py
@@ -1,0 +1,129 @@
+import os
+import time
+import unittest
+from __main__ import vtk, qt, ctk, slicer
+from slicer.ScriptedLoadableModule import *
+
+#
+# ColorsScalarBarSelfTest
+#
+
+class ColorsScalarBarSelfTest(ScriptedLoadableModule):
+  def __init__(self, parent):
+    ScriptedLoadableModule.__init__(self, parent)
+    self.parent.title = "ColorsScalarBarSelfTest"
+    self.parent.categories = ["Testing.TestCases"]
+    self.parent.dependencies = []
+    self.parent.contributors = ["Kevin Wang (PMH), Nicole Aucoin (BWH)"]
+    self.parent.helpText = """
+    This is a test case for the new vtkSlicerScalarBarActor class.
+    It iterates through all the color nodes and sets them active in the
+    Colors module while the scalar bar widget is displayed.
+    """
+    self.parent.acknowledgementText = """
+    This file was originally developed by Kevin Wang, PMH and was funded by CCO and OCAIRO.
+""" # replace with organization, grant and thanks.
+
+#
+# ColorsScalarBarSelfTestWidget
+#
+
+class ColorsScalarBarSelfTestWidget(ScriptedLoadableModuleWidget):
+
+  def setup(self):
+    ScriptedLoadableModuleWidget.setup(self)
+
+    # Instantiate and connect widgets ...
+
+    #
+    # Parameters Area
+    #
+    parametersCollapsibleButton = ctk.ctkCollapsibleButton()
+    parametersCollapsibleButton.text = "Parameters"
+    self.layout.addWidget(parametersCollapsibleButton)
+
+    # Layout within the dummy collapsible button
+    parametersFormLayout = qt.QFormLayout(parametersCollapsibleButton)
+
+    # Apply Button
+    #
+    self.applyButton = qt.QPushButton("Apply")
+    self.applyButton.toolTip = "Run the algorithm."
+    self.applyButton.enabled = True
+    parametersFormLayout.addRow(self.applyButton)
+
+    # connections
+    self.applyButton.connect('clicked(bool)', self.onApplyButton)
+
+    # Add vertical spacer
+    self.layout.addStretch(1)
+
+  def cleanup(self):
+    pass
+
+  def onApplyButton(self):
+    logic =ColorsScalarBarSelfTestLogic()
+    print("Run the test algorithm")
+    logic.run()
+
+#
+#ColorsScalarBarSelfTestLogic
+#
+
+class ColorsScalarBarSelfTestLogic(ScriptedLoadableModuleLogic):
+
+  def run(self):
+    """
+    Run the actual algorithm
+    """
+    # start in the colors module
+    m = slicer.util.mainWindow()
+    m.moduleSelector().selectModule('Colors')
+    self.delayDisplay('In Colors module')
+
+    colorWidget = slicer.modules.colors.widgetRepresentation()
+    ctkScalarBarWidget = slicer.util.findChildren(colorWidget, name='VTKScalarBar')[0]
+    # show the scalar bar widget
+    ctkScalarBarWidget.setDisplay(1)
+    activeColorNodeSelector = slicer.util.findChildren(colorWidget, 'ColorTableComboBox')[0]
+    useColorNameAsLabelCheckbox = slicer.util.findChildren(colorWidget, 'UseColorNameAsLabelCheckBox')[0]
+    checked = useColorNameAsLabelCheckbox.isChecked()
+    # iterate over the color nodes and set each one active
+    numColorNodes = slicer.mrmlScene.GetNumberOfNodesByClass('vtkMRMLColorNode')
+    for n in range(numColorNodes):
+      colorNode = slicer.mrmlScene.GetNthNodeByClass(n, 'vtkMRMLColorNode')
+      useColorNameAsLabelCheckbox.setChecked(checked)
+      print("%d/%d" % (n, numColorNodes-1))
+      self.delayDisplay('Setting Color Node To %s' % colorNode.GetName(), 100)
+      activeColorNodeSelector.setCurrentNodeID(colorNode.GetID())
+      # use the delay display here to ensure a render
+      self.delayDisplay('Set Color Node To %s' % colorNode.GetName(), 500)
+      useColorNameAsLabelCheckbox.setChecked(not checked)
+      self.delayDisplay('Toggled using names as labels', 500)
+
+    return True
+
+class ColorsScalarBarSelfTestTest(ScriptedLoadableModuleTest):
+  """
+  This is the test case for your scripted module.
+  """
+
+  def setUp(self):
+    """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+    """
+    slicer.mrmlScene.Clear(0)
+
+  def runTest(self):
+    """Run as few or as many tests as needed here.
+    """
+    self.setUp()
+    self.test_ColorsScalarBarSelfTest1()
+
+  def test_ColorsScalarBarSelfTest1(self):
+
+    self.delayDisplay("Starting the scalarbar test")
+
+    logic =ColorsScalarBarSelfTestLogic()
+    logic.run()
+
+    self.delayDisplay('Test passed!')

--- a/Modules/Loadable/Colors/VTKWidgets/CMakeLists.txt
+++ b/Modules/Loadable/Colors/VTKWidgets/CMakeLists.txt
@@ -1,0 +1,25 @@
+project(vtkSlicer${MODULE_NAME}ModuleVTKWidgets)
+
+set(KIT ${PROJECT_NAME})
+
+set(${KIT}_EXPORT_DIRECTIVE "VTK_SLICER_${MODULE_NAME_UPPER}_VTKWIDGETS_EXPORT")
+
+set(${KIT}_INCLUDE_DIRECTORIES
+  )
+
+set(${KIT}_SRCS
+  vtkSlicerScalarBarActor.cxx
+  vtkSlicerScalarBarActor.h
+  )
+
+set(${KIT}_TARGET_LIBRARIES
+  )
+
+#-----------------------------------------------------------------------------
+SlicerMacroBuildModuleLogic(
+  NAME ${KIT}
+  EXPORT_DIRECTIVE ${${KIT}_EXPORT_DIRECTIVE}
+  INCLUDE_DIRECTORIES ${${KIT}_INCLUDE_DIRECTORIES}
+  SRCS ${${KIT}_SRCS}
+  TARGET_LIBRARIES ${${KIT}_TARGET_LIBRARIES}
+  )

--- a/Modules/Loadable/Colors/VTKWidgets/vtkSlicerScalarBarActor.cxx
+++ b/Modules/Loadable/Colors/VTKWidgets/vtkSlicerScalarBarActor.cxx
@@ -1,0 +1,449 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kevin Wang, Princess Margaret Cancer Centre
+  and was supported by Cancer Care Ontario (CCO)'s ACRU program
+  with funds provided by the Ontario Ministry of Health and Long-Term Care
+  and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO)
+
+==============================================================================*/
+
+// SlicerRt includes
+#include "vtkSlicerScalarBarActor.h"
+
+// VTK includes
+#include <vtkObjectFactory.h>
+#include <vtkPolyDataMapper2D.h>
+#include <vtkScalarsToColors.h>
+#include <vtkTextMapper.h>
+#include <vtkTextProperty.h>
+#include <vtkViewport.h>
+#include <vtkLookupTable.h>
+#include <vtkSmartPointer.h>
+#if (VTK_MAJOR_VERSION <= 5)
+#else
+#include <vtkScalarBarActorInternal.h>
+#include <vtksys/RegularExpression.hxx>
+#include <vtkTextActor.h>
+
+#include <stdio.h> // for snprintf
+
+#if defined(_WIN32) && !defined(__CYGWIN__)
+#  define SNPRINTF _snprintf
+#else
+#  define SNPRINTF snprintf
+#endif
+#endif
+
+vtkStandardNewMacro(vtkSlicerScalarBarActor);
+
+//---------------------------------------------------------------------------
+vtkSlicerScalarBarActor::vtkSlicerScalarBarActor()
+{
+#if (VTK_MAJOR_VERSION <= 5)
+  this->ColorNames = NULL;
+  vtkSmartPointer<vtkStringArray> colorNames = vtkSmartPointer<vtkStringArray>::New();
+  this->SetColorNames(colorNames);
+  this->UseColorNameAsLabel = 0;
+#else
+  this->Superclass::DrawAnnotationsOff();
+  this->UseAnnotationAsLabel = 0;
+#endif
+}
+
+//----------------------------------------------------------------------------
+vtkSlicerScalarBarActor::~vtkSlicerScalarBarActor()
+{
+#if (VTK_MAJOR_VERSION <= 5)
+  this->SetColorNames(NULL);
+#endif
+}
+
+//----------------------------------------------------------------------------
+void vtkSlicerScalarBarActor::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os,indent);
+
+#if (VTK_MAJOR_VERSION <= 5)
+  os << indent << "UseColorNameAsLabel:   " << this->UseColorNameAsLabel << "\n";
+#else
+  os << indent << "UseAnnotationAsLabel:   " << this->UseAnnotationAsLabel << "\n";
+#endif
+}
+
+#if (VTK_MAJOR_VERSION <= 5)
+//---------------------------------------------------------------------------
+int vtkSlicerScalarBarActor::SetColorName(int ind, const char *name)
+{
+  if (!this->LookupTable)
+    {
+    vtkWarningMacro(<<"Need a lookup table to render a scalar bar");
+    return 0;
+    }
+  vtkLookupTable* lookupTable = vtkLookupTable::SafeDownCast(this->LookupTable);
+  if (lookupTable)
+    {
+    if (lookupTable->GetNumberOfColors() != this->ColorNames->GetNumberOfValues())
+      {
+      this->ColorNames->SetNumberOfValues(lookupTable->GetNumberOfColors());
+      }
+
+    vtkStdString newName(name);
+    if (this->ColorNames->GetValue(ind) != newName)
+      {
+      this->ColorNames->SetValue(ind, newName);
+      }
+    }
+  return 1;
+}
+
+//----------------------------------------------------------------------------
+void vtkSlicerScalarBarActor::AllocateAndSizeLabels(int *labelSize,
+                                              int *size,
+                                              vtkViewport *viewport,
+                                              double *range)
+{
+  labelSize[0] = labelSize[1] = 0;
+
+  if (this->GetUseColorNameAsLabel() == 1)
+    {
+    this->NumberOfLabels = this->ColorNames->GetNumberOfValues();
+    }
+
+  this->TextMappers = new vtkTextMapper * [this->NumberOfLabels];
+  this->TextActors = new vtkActor2D * [this->NumberOfLabels];
+
+  char string[512];
+
+  double val = 0.0; //TODO: Better variable name
+  int i = 0;
+
+  // TODO: this should be optimized, maybe by keeping a list of
+  // allocated mappers, in order to avoid creation/destruction of
+  // their underlying text properties (i.e. each time a mapper is
+  // created, text properties are created and shallow-assigned a font size
+  // which value might be "far" from the target font size).
+
+  // is this a vtkLookupTable or a subclass of vtkLookupTable
+  // with its scale set to log
+  int isLogTable = this->LookupTable->UsingLogScale();
+
+  for (i=0; i < this->NumberOfLabels; i++)
+    {
+    this->TextMappers[i] = vtkTextMapper::New();
+
+    if ( isLogTable )
+      {
+      double lval;
+      if (this->NumberOfLabels > 1)
+        {
+        lval = log10(range[0]) +
+          static_cast<double>(i)/(this->NumberOfLabels-1) *
+          (log10(range[1])-log10(range[0]));
+        }
+      else
+        {
+        lval = log10(range[0]) + 0.5*(log10(range[1])-log10(range[0]));
+        }
+      val = pow(10.0,lval);
+      }
+    else
+      {
+      if (this->NumberOfLabels > 1)
+        {
+        val = range[0] +
+          static_cast<double>(i)/(this->NumberOfLabels-1)
+          * (range[1]-range[0]);
+        }
+      else
+        {
+        val = range[0] + 0.5*(range[1]-range[0]);
+        }
+      }
+    //
+    if (this->GetUseColorNameAsLabel() == 1)
+      {
+      strcpy(string, this->ColorNames->GetValue(i).c_str());
+      }
+    else
+      {
+      sprintf(string, this->LabelFormat, val);
+      }
+    this->TextMappers[i]->SetInput(string);
+
+    // Shallow copy here so that the size of the label prop is not affected
+    // by the automatic adjustment of its text mapper's size (i.e. its
+    // mapper's text property is identical except for the font size
+    // which will be modified later). This allows text actors to
+    // share the same text property, and in that case specifically allows
+    // the title and label text prop to be the same.
+    this->TextMappers[i]->GetTextProperty()->ShallowCopy(
+      this->LabelTextProperty);
+
+    this->TextActors[i] = vtkActor2D::New();
+    this->TextActors[i]->SetMapper(this->TextMappers[i]);
+    this->TextActors[i]->SetProperty(this->GetProperty());
+    this->TextActors[i]->GetPositionCoordinate()->
+      SetReferenceCoordinate(this->PositionCoordinate);
+    }
+
+  if (this->NumberOfLabels)
+    {
+    int targetWidth, targetHeight;
+
+    if ( this->Orientation == VTK_ORIENT_VERTICAL )
+      {
+      targetWidth = static_cast<int>(0.6*size[0]);
+      targetHeight = static_cast<int>(0.86*size[1]/this->NumberOfLabels);
+      }
+    else
+      {
+      targetWidth = static_cast<int>(size[0]*0.8/this->NumberOfLabels);
+      targetHeight = static_cast<int>(0.25*size[1]);
+      }
+
+    vtkTextMapper::SetMultipleConstrainedFontSize(viewport,
+                                                  targetWidth,
+                                                  targetHeight,
+                                                  this->TextMappers,
+                                                  this->NumberOfLabels,
+                                                  labelSize);
+    }
+}
+#else
+//-----------------------------------------------------------------------------
+void vtkSlicerScalarBarActor::LayoutTicks()
+{
+  if (this->LookupTable->GetIndexedLookup())
+    { // no tick marks in indexed lookup mode.
+    this->NumberOfLabelsBuilt = 0;
+    return;
+    }
+
+  // find the best size for the ticks
+  double* range = this->LookupTable->GetRange();
+
+  // TODO: this should be optimized, maybe by keeping a list of
+  // allocated mappers, in order to avoid creation/destruction of
+  // their underlying text properties (i.e. each time a mapper is
+  // created, text properties are created and shallow-assigned a font size
+  // which value might be "far" from the target font size).
+  this->Superclass::P->TextActors.resize(this->NumberOfLabels);
+
+  // Does this map have its scale set to log?
+  int isLogTable = this->LookupTable->UsingLogScale();
+
+  // only print warning once in loop
+  bool formatWarningPrinted = false;
+
+  for (int i = 0; i < this->NumberOfLabels; i++)
+    {
+    this->P->TextActors[i].TakeReference(vtkTextActor::New());
+
+    double val = 0.0;
+    char labelString[512];
+    // default in case of error with the annotations
+    SNPRINTF(labelString, 511, "(none)");
+
+    if ( isLogTable )
+      {
+      double lval;
+      if (this->NumberOfLabels > 1)
+        {
+        lval = log10(range[0]) +
+          static_cast<double>(i)/(this->NumberOfLabels-1) *
+          (log10(range[1])-log10(range[0]));
+        }
+      else
+        {
+        lval = log10(range[0]) + 0.5*(log10(range[1])-log10(range[0]));
+        }
+      val = pow(10.0,lval);
+      }
+    else
+      {
+      if (this->NumberOfLabels > 1)
+        {
+        val = range[0] +
+          static_cast<double>(i)/(this->NumberOfLabels-1)
+          * (range[1]-range[0]);
+        }
+      else
+        {
+        val = range[0] + 0.5*(range[1]-range[0]);
+        }
+      }
+
+    // if the lookuptable uses the new annotation functionality in VTK6.0
+    // then use it as labels
+    int numberOfAnnotatedValues = this->LookupTable->GetNumberOfAnnotatedValues();
+    if (this->UseAnnotationAsLabel == 1)
+      {
+      if (numberOfAnnotatedValues > 1)
+        {
+        double indx = 0.0;
+        int index  = 0;
+        if (this->NumberOfLabels > 1)
+          {
+          indx = static_cast<double>(i)/(this->NumberOfLabels-1)*(numberOfAnnotatedValues-1);
+          }
+        else
+          {
+          indx = 0.5*numberOfAnnotatedValues;
+          }
+        index = static_cast<int>(indx+0.5);
+        // try to make sure the label format supports a string
+        // TODO issue 2919: replace with a more strict regular expression
+        //
+        vtksys::RegularExpression regExForString("%.*s");
+        if (regExForString.find(this->LabelFormat))
+          {
+          SNPRINTF(labelString, 511, this->LabelFormat, this->LookupTable->GetAnnotation(index).c_str());
+          }
+        else
+          {
+          if (!formatWarningPrinted)
+            {
+            vtkWarningMacro("LabelFormat doesn't contain a string specifier!" << this->LabelFormat);
+            formatWarningPrinted = true;
+            }
+          }
+        }
+      }
+    else
+      {
+      // try to make sure the label format supports a floating point number
+      // TODO: replace with more strict regular expression
+      vtksys::RegularExpression regExForDouble("%.*[fFgGeE]");
+      if (regExForDouble.find(this->LabelFormat))
+          {
+          SNPRINTF(labelString, 511, this->LabelFormat, val);
+          }
+        else
+          {
+          if (!formatWarningPrinted)
+            {
+            vtkWarningMacro("LabelFormat doesn't contain a floating point specifier!" << this->LabelFormat);
+            formatWarningPrinted = true;
+            }
+          }
+      }
+    this->P->TextActors[i]->SetInput(labelString);
+
+    // Shallow copy here so that the size of the label prop is not affected
+    // by the automatic adjustment of its text mapper's size (i.e. its
+    // mapper's text property is identical except for the font size
+    // which will be modified later). This allows text actors to
+    // share the same text property, and in that case specifically allows
+    // the title and label text prop to be the same.
+    this->P->TextActors[i]->GetTextProperty()->ShallowCopy(
+      this->LabelTextProperty);
+
+    this->P->TextActors[i]->SetProperty(this->GetProperty());
+    this->P->TextActors[i]->GetPositionCoordinate()->
+      SetReferenceCoordinate(this->PositionCoordinate);
+    }
+
+  if (this->NumberOfLabels)
+    {
+    int labelSize[2];
+    labelSize[0] = labelSize[1] = 0;
+    int targetWidth, targetHeight;
+
+    this->P->TickBox.Posn = this->P->ScalarBarBox.Posn;
+    if ( this->Orientation == VTK_ORIENT_VERTICAL )
+      { // NB. Size[0] = width, Size[1] = height
+      // Ticks share the width with the scalar bar
+      this->P->TickBox.Size[0] =
+        this->P->Frame.Size[0] - this->P->ScalarBarBox.Size[0] -
+        this->TextPad * 3;
+      // Tick height could be adjusted if title text is
+      // lowered by box constraints, but we won't bother:
+      this->P->TickBox.Size[1] = this->P->Frame.Size[1] -
+        this->P->TitleBox.Size[1] - 3 * this->TextPad -
+        this->VerticalTitleSeparation;
+      // Tick box height also reduced by NaN swatch size, if present:
+      if (this->DrawNanAnnotation)
+        {
+        this->P->TickBox.Size[1] -=
+          this->P->NanBox.Size[1] + this->P->SwatchPad;
+        }
+
+      if (this->TextPosition == vtkScalarBarActor::PrecedeScalarBar)
+        {
+        this->P->TickBox.Posn[0] = this->TextPad;
+        }
+      else
+        {
+        this->P->TickBox.Posn[0] += this->P->ScalarBarBox.Size[0] + 2 * this->TextPad;
+        }
+
+      targetWidth = this->P->TickBox.Size[0];
+      targetHeight = static_cast<int>((this->P->TickBox.Size[1] -
+          this->TextPad * (this->NumberOfLabels - 1)) /
+        this->NumberOfLabels);
+      }
+    else
+      { // NB. Size[1] = width, Size[0] = height
+      // Ticks span the entire width of the frame
+      this->P->TickBox.Size[1] = this->P->ScalarBarBox.Size[1];
+      // Ticks share vertical space with title and scalar bar.
+      this->P->TickBox.Size[0] =
+        this->P->Frame.Size[0] - this->P->ScalarBarBox.Size[0] -
+        4 * this->TextPad - this->P->TitleBox.Size[0];
+
+      if (this->TextPosition == vtkScalarBarActor::PrecedeScalarBar)
+        {
+        this->P->TickBox.Posn[1] =
+          this->P->TitleBox.Size[0] + 2 * this->TextPad;
+        /* or equivalently: Posn[1] -=
+          this->P->Frame.Size[0] -
+          this->P->TitleBox.Size[0] - this->TextPad -
+          this->P->ScalarBarBox.Size[0];
+          */
+        }
+      else
+        {
+        this->P->TickBox.Posn[1] += this->P->ScalarBarBox.Size[0];
+        }
+
+      targetWidth = static_cast<int>((this->P->TickBox.Size[1] -
+          this->TextPad * (this->NumberOfLabels - 1)) /
+        this->NumberOfLabels);
+      targetHeight = this->P->TickBox.Size[0];
+      }
+
+    vtkTextActor::SetMultipleConstrainedFontSize(
+      this->P->Viewport, targetWidth, targetHeight,
+      this->P->TextActors.PointerArray(), this->NumberOfLabels,
+      labelSize);
+
+    // Now adjust scalar bar size by the half-size of the first and last ticks
+    this->P->ScalarBarBox.Posn[this->P->TL[1]]
+      += labelSize[this->P->TL[1]] / 2.;
+    this->P->ScalarBarBox.Size[1] -= labelSize[this->P->TL[1]];
+    this->P->TickBox.Posn[this->P->TL[1]] += labelSize[this->P->TL[1]] / 2.;
+    this->P->TickBox.Size[1] -= labelSize[this->P->TL[1]];
+
+    if (this->Orientation == VTK_ORIENT_HORIZONTAL)
+      {
+      this->P->TickBox.Posn[1] += this->TextPad *
+        (this->TextPosition == PrecedeScalarBar ? -1 : +1);
+      this->P->TickBox.Size[1] -= this->TextPad;
+      }
+    }
+  this->NumberOfLabelsBuilt = this->NumberOfLabels;
+}
+#endif

--- a/Modules/Loadable/Colors/VTKWidgets/vtkSlicerScalarBarActor.h
+++ b/Modules/Loadable/Colors/VTKWidgets/vtkSlicerScalarBarActor.h
@@ -1,0 +1,110 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kevin Wang, Princess Margaret Cancer Centre
+  and was supported by Cancer Care Ontario (CCO)'s ACRU program
+  with funds provided by the Ontario Ministry of Health and Long-Term Care
+  and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO)
+
+==============================================================================*/
+
+///  vtkSliceRTScalarBarActor - slicer vtk class for adding color names in scalarbar
+///
+/// This class enhances the vtkScalarBarActor class by adding color names
+/// in the label display.
+
+#ifndef __vtkSlicerScalarBarActor_h
+#define __vtkSlicerScalarBarActor_h
+
+// VTK includes
+#include "vtkScalarBarActor.h"
+#include "vtkStringArray.h"
+#include "vtkVersion.h"
+
+// MRMLLogic includes
+#include "vtkSlicerColorsModuleVTKWidgetsExport.h"
+
+/// \ingroup SlicerRt_QtModules_Isodose
+class VTK_SLICER_COLORS_VTKWIDGETS_EXPORT vtkSlicerScalarBarActor
+  : public vtkScalarBarActor
+{
+public:
+  // The usual VTK class functions
+  static vtkSlicerScalarBarActor *New();
+  vtkTypeMacro(vtkSlicerScalarBarActor,vtkScalarBarActor);
+  void PrintSelf(ostream& os, vtkIndent indent);
+
+#if (VTK_MAJOR_VERSION <= 5)
+  /// Get for the flag on using color names as label
+  vtkGetMacro(UseColorNameAsLabel, int);
+  /// Set for the flag on using color names as label
+  vtkSetMacro(UseColorNameAsLabel, int);
+  /// Get/Set for the flag on using color names as label
+  vtkBooleanMacro(UseColorNameAsLabel, int);
+
+  /// Get color names array
+  vtkGetObjectMacro(ColorNames, vtkStringArray);
+
+  /// Set the ith color name.
+  int SetColorName(int ind, const char *name);
+
+protected:
+  /// Set color names array
+  vtkSetObjectMacro(ColorNames, vtkStringArray);
+
+#else
+  /// Get for the flag on using VTK6 annotation as label
+  vtkGetMacro(UseAnnotationAsLabel, int);
+  /// Set for the flag on using VTK6 annotation as label
+  vtkSetMacro(UseAnnotationAsLabel, int);
+  /// Get/Set for the flag on using VTK6 annotation as label
+  vtkBooleanMacro(UseAnnotationAsLabel, int);
+#endif
+
+protected:
+  vtkSlicerScalarBarActor();
+  ~vtkSlicerScalarBarActor();
+
+#if (VTK_MAJOR_VERSION <= 5)
+  /// overloaded virtual function that adds the color name as label
+  virtual void AllocateAndSizeLabels(int *labelSize, int *size,
+                                     vtkViewport *viewport, double *range);
+
+  /// A vector of names for the color table elements
+  vtkStringArray* ColorNames;
+
+  /// flag for setting color name as label
+  int UseColorNameAsLabel;
+#else
+  // Description:
+  // Determine the size and placement of any tick marks to be rendered.
+  //
+  // This method must set this->P->TickBox.
+  // It may depend on layout performed by ComputeScalarBarLength.
+  //
+  // The default implementation creates exactly this->NumberOfLabels
+  // tick marks, uniformly spaced on a linear or logarithmic scale.
+  virtual void LayoutTicks();
+
+  /// flag for setting color name as label
+  int UseAnnotationAsLabel;
+#endif
+
+private:
+  vtkSlicerScalarBarActor(const vtkSlicerScalarBarActor&);  // Not implemented.
+  void operator=(const vtkSlicerScalarBarActor&);  // Not implemented.
+};
+
+#endif

--- a/Modules/Loadable/Colors/qSlicerColorsModuleWidget.h
+++ b/Modules/Loadable/Colors/qSlicerColorsModuleWidget.h
@@ -46,6 +46,7 @@ public slots:
   void updateNumberOfColors();
   void setLookupTableRange(double min, double max);
   void copyCurrentColorNode();
+  void setUseColorNameAsLabel(bool);
 
 protected slots:
   void onMRMLColorNodeChanged(vtkMRMLNode* newColorNode);


### PR DESCRIPTION
The VTK6 vtkScalarBarActor class allows displaying annotations in conjunction with labels.
However, in Slicer we want to sample the annotations for display just like color values since some color
tables have more than 10000 values and annotations.
The vtkSlicerScalarBarActor is based on vtkScalarBarActor class and only overrides its LayoutTicks method
to slightly modify the method to enable sampling the annotations and display it as labels.
Also change colors module logic using the new class.
Keep backward compatibility to VTK5.
Also added a python selftest based on scripted module superclass.
Added a check box to toggle using the color names as labels, and set default label formats when it's toggled
to support strings or numbers. Added simple label format testing to avoid crashes that were seen when using
a string format with a number value. Refer to bug report in TODO.

Joint work between Kevin Wang and Nicole Aucoin

Issue #2919
