### PR TITLE
ENH: Fixed issues 3579, 3798 and other dicom browser improvements

### DIFF
--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -272,7 +272,7 @@ class DICOMWidget:
     # connect to the main window's dicom button
     mw = slicer.util.mainWindow()
     try:
-      action = slicer.util.findChildren(mw,name='actionLoadDICOM')[0]
+      action = slicer.util.findChildren(mw,name='LoadDICOMAction')[0]
       action.connect('triggered()',self.detailsPopup.open)
     except IndexError:
       print('Could not connect to the main window DICOM button')


### PR DESCRIPTION
@jcfr @pieper 
Improvements:
- Added the table density control to the slicer dicom browser for  controlling table densities in three levels: comact, cozy and  comfortable. The default value would be compact. Changing the settings
  would be saved in slicer user settings. (This will fix [1])
- Re-arranged the patient, study and series search boxex so that the  search box will be on the top of tables for both horizontal and vertical  cases (This will add more space to dicom tables)
- The bug with browser size change on advanced view is fixed (issue #3798 [2])
- The feature to resize tables based on contents was added to the tables.

[1] http://na-mic.org/Mantis/view.php?id=3579
[2] http://na-mic.org/Mantis/view.php?id=3798
