### PR TITLE
ENH: Added icon loading for scripted module base class

### DIFF
--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -4,24 +4,31 @@ from __main__ import qt, ctk, slicer
 
 class ScriptedLoadableModule:
   def __init__(self, parent):
+    self.parent = parent
+    self.moduleName = self.__class__.__name__
+
     parent.title = ""
     parent.categories = []
     parent.dependencies = []
     parent.contributors = []
+
     parent.helpText = string.Template("""
 This module was created from a template and the help section has not yet been updated.
 
 Please refer to <a href=\"$a/Documentation/$b.$c/Modules/ScriptedLoadableModule\">the documentation</a>.
 
     """).substitute({ 'a':parent.slicerWikiUrl, 'b':slicer.app.majorVersion, 'c':slicer.app.minorVersion })
+
     parent.acknowledgementText = """
 This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community. See <a>http://www.slicer.org</a> for details.  Module implemented by Steve Pieper.
 This work is partially supported by PAR-07-249: R01CA131718 NA-MIC Virtual Colonoscopy (See <a href=http://www.slicer.org>http://www.na-mic.org/Wiki/index.php/NA-MIC_NCBC_Collaboration:NA-MIC_virtual_colonoscopy</a>).
     """
-    parent.acknowledgementText = ""
-    self.parent = parent
 
-    self.moduleName = self.__class__.__name__
+    # Set module icon from Resources/Icons/<ModuleName>.png
+    moduleDir = os.path.dirname(self.parent.path)
+    iconPath = moduleDir+'/Resources/Icons/'+self.moduleName+'.png'
+    if os.path.isfile(iconPath):
+      parent.icon = qt.QIcon(iconPath)
 
     # Add this test to the SelfTest module's list for discovery when the module
     # is created.  Since this module may be discovered before SelfTests itself,

--- a/Extensions/Testing/ScriptedLoadableExtensionTemplate/ScriptedLoadableModuleTemplate/CMakeLists.txt
+++ b/Extensions/Testing/ScriptedLoadableExtensionTemplate/ScriptedLoadableModuleTemplate/CMakeLists.txt
@@ -7,6 +7,7 @@ set(MODULE_PYTHON_SCRIPTS
   )
 
 set(MODULE_PYTHON_RESOURCES
+  Resources/Icons/${MODULE_NAME}.png
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Scripted/VectorToScalarVolume/VectorToScalarVolume.py
+++ b/Modules/Scripted/VectorToScalarVolume/VectorToScalarVolume.py
@@ -4,40 +4,31 @@ from __main__ import vtk, qt, ctk, slicer
 # VectorToScalarVolume
 #
 
-class VectorToScalarVolume:
+class VectorToScalarVolume(ScriptedLoadableModule):
   def __init__(self, parent):
-    parent.title = "Vector to Scalar Volume"
-    parent.categories = ["Converters"]
-    parent.dependencies = []
-    parent.contributors = ["Steve Pieper (Isomics)",]
-    parent.helpText = """
+    ScriptedLoadableModule.__init__(self, parent)
+    self.parent.title = "Vector to Scalar Volume"
+    self.parent.categories = ["Converters"]
+    self.parent.dependencies = []
+    self.parent.contributors = ["Steve Pieper (Isomics)",]
+    self.parent.helpText = """
     Make a scalar (1 component) volume from a vector volume
     """
-    parent.acknowledgementText = """
+    self.parent.acknowledgementText = """
 Developed by Steve Pieper, Isomics, Inc.,
 partially funded by NIH grant 3P41RR013218-12S1 (NAC) and is part of the National Alliance
 for Medical Image Computing (NA-MIC), funded by the National Institutes of Health through the
 NIH Roadmap for Medical Research, Grant U54 EB005149."""
-    self.parent = parent
 
 #
 # VectorToScalarVolumeWidget
 #
 
-class VectorToScalarVolumeWidget:
-  def __init__(self, parent = None):
-    if not parent:
-      self.parent = slicer.qMRMLWidget()
-      self.parent.setLayout(qt.QVBoxLayout())
-      self.parent.setMRMLScene(slicer.mrmlScene)
-    else:
-      self.parent = parent
-    self.layout = self.parent.layout()
-    if not parent:
-      self.setup()
-      self.parent.show()
+class VectorToScalarVolumeWidget(ScriptedLoadableModuleWidget):
 
   def setup(self):
+    ScriptedLoadableModuleWidget.setup(self)
+
     # Collapsible button
     self.selectionCollapsibleButton = ctk.ctkCollapsibleButton()
     self.selectionCollapsibleButton.text = "Selection"

--- a/Utilities/Templates/Modules/Scripted/CMakeLists.txt
+++ b/Utilities/Templates/Modules/Scripted/CMakeLists.txt
@@ -7,6 +7,7 @@ set(MODULE_PYTHON_SCRIPTS
   )
 
 set(MODULE_PYTHON_RESOURCES
+  Resources/Icons/${MODULE_NAME}.png
   )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Python scripted modules that use the ScriptedLoadableModule base class now load their icon from Resources/Icons/<ModuleName>.png.
If the icon file does not exist then the default icon is kept.
Modules can override the icon setting in the module **init** function to use any other custom icon.

Updated extension wizard template and extension test.

Updated one more module (VectorToScalarVolume) to use ScriptedLoadableModule base class.
