### PR TITLE
Fix compilation errors with ITK_USE_64BITS_IDS

### DIFF
--- a/Libs/vtkITK/itkTimeSeriesDatabase.txx
+++ b/Libs/vtkITK/itkTimeSeriesDatabase.txx
@@ -30,12 +30,12 @@ bool TimeSeriesDatabase<TPixel>::CalculateIntersection ( Size<3> BlockIndex,
   bool IsFullBlock = true;
   for ( unsigned int i = 0; i < 3; i++ )
   {
-    ImageRegion.SetIndex ( i, TSD_MAX ( (long unsigned int) RequestedRegion.GetIndex ( i ), TimeSeriesBlockSize * BlockIndex[i] ) );
+    ImageRegion.SetIndex ( i, TSD_MAX<itk::IndexValueType> ( RequestedRegion.GetIndex ( i ), TimeSeriesBlockSize * BlockIndex[i] ) );
     BlockRegion.SetIndex ( i, ImageRegion.GetIndex(i) % TimeSeriesBlockSize );
 
     // This is the end index
     long unsigned int Tmp = RequestedRegion.GetIndex ( i ) + RequestedRegion.GetSize ( i );
-    Tmp = TSD_MIN ( (long unsigned int) Tmp, TimeSeriesBlockSize * (BlockIndex[i]+1) );
+    Tmp = TSD_MIN<itk::IndexValueType> ( Tmp, TimeSeriesBlockSize * (BlockIndex[i]+1) );
     Tmp = Tmp - ImageRegion.GetIndex(i);
 
     ImageRegion.SetSize ( i, Tmp );

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesScalarReader.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesScalarReader.cxx
@@ -124,7 +124,7 @@ int vtkITKArchetypeImageSeriesScalarReader::RequestData(
         filter = orient##typeN; \
         }\
       filter->UpdateLargestPossibleRegion(); \
-      itk::ImportImageContainer<unsigned long, type>::Pointer PixelContainer##typeN;\
+	  itk::ImportImageContainer<itk::SizeValueType, type>::Pointer PixelContainer##typeN;\
       PixelContainer##typeN = filter->GetOutput()->GetPixelContainer();\
       void *ptr = static_cast<void *> (PixelContainer##typeN->GetBufferPointer());\
       DownCast<type>(data->GetPointData()->GetScalars())                \
@@ -158,7 +158,7 @@ int vtkITKArchetypeImageSeriesScalarReader::RequestData(
         filter = orient2##typeN; \
         } \
        filter->UpdateLargestPossibleRegion();\
-      itk::ImportImageContainer<unsigned long, type>::Pointer PixelContainer2##typeN;\
+	  itk::ImportImageContainer<itk::SizeValueType, type>::Pointer PixelContainer2##typeN;\
       PixelContainer2##typeN = filter->GetOutput()->GetPixelContainer();\
       void *ptr = static_cast<void *> (PixelContainer2##typeN->GetBufferPointer());\
       DownCast<type>(data->GetPointData()->GetScalars())                \

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.cxx
@@ -88,7 +88,7 @@ void vtkITKExecuteDataFromFileVector(
     filter = orient2;
     }
    filter->UpdateLargestPossibleRegion();
-  typename itk::ImportImageContainer<unsigned long, T>::Pointer PixelContainer2;
+  typename itk::ImportImageContainer<itk::SizeValueType, T>::Pointer PixelContainer2;
   PixelContainer2 = filter->GetOutput()->GetPixelContainer();
   void *ptr = static_cast<void *> (PixelContainer2->GetBufferPointer());
   DownCast<T>(data->GetPointData()->GetScalars())

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderSeries.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderSeries.cxx
@@ -100,7 +100,7 @@ void vtkITKExecuteDataFromSeriesVector(
     filter = orient;
     }
   filter->UpdateLargestPossibleRegion();
-  typename itk::ImportImageContainer<unsigned long, VectorPixelType>::Pointer PixelContainer;
+  typename itk::ImportImageContainer<itk::SizeValueType, VectorPixelType>::Pointer PixelContainer;
   PixelContainer = filter->GetOutput()->GetPixelContainer();
   void *ptr = static_cast<void *> (PixelContainer->GetBufferPointer());
   DownCast<T>(data->GetPointData()->GetScalars())

--- a/Libs/vtkITK/vtkITKTimeSeriesDatabase.cxx
+++ b/Libs/vtkITK/vtkITKTimeSeriesDatabase.cxx
@@ -63,7 +63,7 @@ void vtkITKTimeSeriesDatabase::ExecuteDataWithInformation(vtkDataObject *output,
   {
     this->AllocateOutputData(output, outInfo);
 #endif
-    itk::ImportImageContainer<unsigned long, OutputImagePixelType>::Pointer PixelContainerShort;
+	itk::ImportImageContainer<itk::SizeValueType, OutputImagePixelType>::Pointer PixelContainerShort;
     PixelContainerShort = this->m_Filter->GetOutput()->GetPixelContainer();
     void *ptr = static_cast<void *> (PixelContainerShort->GetBufferPointer());
     vtkUnsignedLongArray::SafeDownCast(


### PR DESCRIPTION
Enabling this cmake configuration flag for ITK changes the size types
used in ITK from ulong to ulong long on windows. This patch address
compilation errors which resulted from this change. The
itk::SizeValueType is preferred type, or a referenced typedef from the
related ITK class being used.
