### PR TITLE
BUG: Fixed two minor issues of slice view annotations

### DIFF
--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -575,7 +575,7 @@ class SliceAnnotations(object):
 
   def createColorScalarBar(self, sliceViewName):
     scalarBar = slicer.vtkPVScalarBarActor()
-    scalarBar.SetTitle("")
+    scalarBar.SetTitle(" ")
     # adjust text property
     scalarBar.SetRangeLabelFormat('%.0f')
     lookupTable = vtk.vtkLookupTable()
@@ -592,6 +592,7 @@ class SliceAnnotations(object):
         self.sliceViewNames.append(sliceViewName)
         self.addObserver(sliceViewName)
         self.createActors(sliceViewName)
+        self.updateSliceViewFromGUI()
     self.makeAnnotationText(caller)
     self.makeScalingRuler(caller)
     self.makeColorScalarBar(caller)


### PR DESCRIPTION
- Fixed the error in the terminal No scalar values found for texture input!
- New slices that are added to the layout would have the same font
  settings as the other slices.
