### PR TITLE
ENH: generalise comparing volume geometries

### DIFF
--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -877,7 +877,7 @@ vtkSlicerVolumesLogic::FillLabelVolumeFromTemplate(vtkMRMLScene *scene,
 //----------------------------------------------------------------------------
 std::string
 vtkSlicerVolumesLogic::CheckForLabelVolumeValidity(vtkMRMLScalarVolumeNode *volumeNode,
-                                          vtkMRMLScalarVolumeNode *labelNode)
+                                                   vtkMRMLScalarVolumeNode *labelNode)
 {
   std::stringstream warnings;
   warnings << "";
@@ -887,7 +887,7 @@ vtkSlicerVolumesLogic::CheckForLabelVolumeValidity(vtkMRMLScalarVolumeNode *volu
       {
       warnings << "Null volume node pointer\n";
       }
-    else
+    if (!labelNode)
       {
       warnings << "Null label volume node pointer\n";
       }

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.h
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.h
@@ -198,7 +198,7 @@ public:
   ///  Same spacing.
   ///  Same origin.
   ///  Same IJKtoRAS.
-  /// \sa CheckForLabelVolumeValidity
+  /// \sa CheckForLabelVolumeValidity, ResampleVolumeToReferenceVolume
   std::string CompareVolumeGeometry(vtkMRMLScalarVolumeNode *volumeNode1,
                                     vtkMRMLScalarVolumeNode *volumeNode2);
 
@@ -238,6 +238,7 @@ public:
   void GetVolumeCenteredOrigin(vtkMRMLVolumeNode *volumeNode, double* origin);
 
   ///  Convenience method to resample input volume using reference volume info
+  /// \sa CompareVolumeGeometry
   static vtkMRMLScalarVolumeNode* ResampleVolumeToReferenceVolume(vtkMRMLVolumeNode *inputVolumeNode,
                                                            vtkMRMLVolumeNode *referenceVolumeNode);
 

--- a/Modules/Loadable/Volumes/Testing/Cxx/vtkSlicerVolumesLogicTest1.cxx
+++ b/Modules/Loadable/Volumes/Testing/Cxx/vtkSlicerVolumesLogicTest1.cxx
@@ -113,5 +113,44 @@ int vtkSlicerVolumesLogicTest1( int argc, char * argv[] )
     volume->GetImageData()->Print(std::cerr);
     }
 
+  // basic checks on volume geometry
+  vtkMRMLScalarVolumeNode *scalarVolume =
+    vtkMRMLScalarVolumeNode::SafeDownCast(volume);
+  if (scalarVolume != NULL)
+    {
+    std::cout << "Testing volume geometry" << std::endl;
+    std::string warnings;
+    warnings = logic->CheckForLabelVolumeValidity(NULL, NULL);
+    if (warnings.empty())
+      {
+      std::cerr << "ERROR: did not detect two null volumes in check for label volume validity" << std::endl;
+      return EXIT_FAILURE;
+      }
+    warnings = logic->CompareVolumeGeometry(NULL, NULL);
+    if (warnings.empty())
+      {
+      std::cerr << "ERROR: did not detect two null volumes in Compare Volume Geometry" << std::endl;
+      return EXIT_FAILURE;
+      }
+    warnings = logic->CheckForLabelVolumeValidity(scalarVolume, NULL);
+    if (warnings.empty())
+      {
+      std::cerr << "ERROR: did not detect null labe volumes in CheckForLabelVolumeValidity" << std::endl;
+      return EXIT_FAILURE;
+      }
+    warnings = logic->CheckForLabelVolumeValidity(NULL, scalarVolume);
+    if (warnings.empty())
+      {
+      std::cerr << "ERROR: did not detect null volumes and incorrect label map in CheckForLabelVolumeValidity" << std::endl;
+      return EXIT_FAILURE;
+      }
+    warnings = logic->CompareVolumeGeometry(scalarVolume, scalarVolume);
+    if (!warnings.empty())
+      {
+      std::cerr << "ERROR: got a warning when comparing identical volumes in CompareVolumeGeometry: " << warnings.c_str() << std::endl;
+      return EXIT_FAILURE;
+      }
+    }
+
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Added CompareVolumeGeometry and call it from CheckForLabelVolumeValidity, allows more general volume geometry comparisons rather than just label map vs grey scale comparisons.
