### PR TITLE
BUG: adjust resample interpolation type for label maps

### DIFF
--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -1463,7 +1463,16 @@ vtkSlicerVolumesLogic
   resliceFilter->SetOutputSpacing(1, 1, 1);
   resliceFilter->SetOutputExtent(0, dimensions[0]-1, 0, dimensions[1]-1, 0, dimensions[2]-1);
   resliceFilter->SetResliceTransform(outputVolumeResliceTransform);
-  resliceFilter->SetInterpolationModeToLinear();
+  // check for a label map and adjust interpolation mode
+  if (inputVolumeNode->IsA("vtkMRMLScalarVolumeNode") &&
+      vtkMRMLScalarVolumeNode::SafeDownCast(inputVolumeNode)->GetLabelMap())
+    {
+    resliceFilter->SetInterpolationModeToNearestNeighbor();
+    }
+  else
+    {
+    resliceFilter->SetInterpolationModeToLinear();
+    }
   resliceFilter->Update();
 
   outputVolumeNode->CopyOrientation(referenceVolumeNode);


### PR DESCRIPTION
The volumes logic method ResampleVolumeToReferenceVolume can be
called with an input label map scalar volume, check for that case.
For label maps we don't want to do a linear interpolation over any data
present as that could result in values not defined in the color look
up table, so use the nearest neighbour filter option instead.
