### PR TITLE
ENH: Add access to the currently selected module for testing convinience

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -310,13 +310,19 @@ def saveScene(filename, properties={}):
 # Module
 #
 
+def moduleSelector():
+  w = mainWindow()
+  if w:
+    return w.moduleSelector()
+
 def selectModule(module):
   moduleName = module
   if not isinstance(module, basestring):
     moduleName = module.name
-  w = mainWindow()
-  if not w: return
-  w.moduleSelector().selectModule(moduleName)
+  moduleSelector().selectModule(moduleName)
+
+def selectedModule():
+  return moduleSelector().selectedModule
 
 def moduleNames():
   from slicer import app

--- a/Base/QTGUI/qSlicerModuleSelectorToolBar.cxx
+++ b/Base/QTGUI/qSlicerModuleSelectorToolBar.cxx
@@ -201,6 +201,13 @@ qSlicerModulesMenu* qSlicerModuleSelectorToolBar::modulesMenu()const
 }
 
 //---------------------------------------------------------------------------
+QString qSlicerModuleSelectorToolBar::selectedModule()const
+{
+  Q_D(const qSlicerModuleSelectorToolBar);
+  return d->ModulesMenu->currentModule();
+}
+
+//---------------------------------------------------------------------------
 void qSlicerModuleSelectorToolBar::setModuleManager(qSlicerModuleManager* moduleManager)
 {
   Q_D(qSlicerModuleSelectorToolBar);

--- a/Base/QTGUI/qSlicerModuleSelectorToolBar.h
+++ b/Base/QTGUI/qSlicerModuleSelectorToolBar.h
@@ -44,6 +44,7 @@ class Q_SLICER_BASE_QTGUI_EXPORT qSlicerModuleSelectorToolBar: public QToolBar
   Q_OBJECT
 public:
   typedef QToolBar Superclass;
+  Q_PROPERTY(QString selectedModule READ selectedModule WRITE selectModule NOTIFY moduleSelected)
 
   /// Constructor
   /// title is the name of the toolbar (can appear using right click on the
@@ -54,6 +55,9 @@ public:
 
   /// Returns a pointer to the modules menu used to populate the list of modules
   qSlicerModulesMenu* modulesMenu()const;
+
+  /// Returns the selected module name
+  QString selectedModule() const;
 
 public slots:
   /// Module manager contains all the loaded modules


### PR DESCRIPTION
Create a Q_PROPERTY in qSlicerModuleSelectorToolBar to make sure it is
wrapped in python. Also add some candy-coating in slicer python util.
