### PR TITLE
BUG: Fixed composite transform problems

### DIFF
--- a/Base/Logic/vtkSlicerApplicationLogic.cxx
+++ b/Base/Logic/vtkSlicerApplicationLogic.cxx
@@ -29,9 +29,6 @@
 #include <vtkMRMLFreeSurferModelStorageNode.h>
 #include <vtkMRMLLabelMapVolumeDisplayNode.h>
 #include <vtkMRMLTransformNode.h>
-#include <vtkMRMLLinearTransformNode.h>
-#include <vtkMRMLBSplineTransformNode.h>
-#include <vtkMRMLGridTransformNode.h>
 #include <vtkMRMLModelNode.h>
 #include <vtkMRMLModelHierarchyNode.h>
 #include <vtkMRMLNRRDStorageNode.h>
@@ -848,9 +845,6 @@ void vtkSlicerApplicationLogic::ProcessReadNodeData(ReadDataRequest& req)
   vtkMRMLDiffusionWeightedVolumeNode *dwvnd = 0;
   vtkMRMLModelNode *mnd = 0;
   vtkMRMLTransformNode *tnd = 0;
-  vtkMRMLLinearTransformNode *ltnd = 0;
-  vtkMRMLBSplineTransformNode *btnd = 0;
-  vtkMRMLGridTransformNode *gtnd = 0;
   vtkMRMLDisplayableNode *fbnd = 0;
   vtkMRMLColorTableNode *cnd = 0;
   vtkMRMLDoubleArrayNode *dand = 0;
@@ -884,9 +878,6 @@ void vtkSlicerApplicationLogic::ProcessReadNodeData(ReadDataRequest& req)
 
   mnd   = vtkMRMLModelNode::SafeDownCast(nd);
   tnd   = vtkMRMLTransformNode::SafeDownCast(nd);
-  ltnd  = vtkMRMLLinearTransformNode::SafeDownCast(nd);
-  btnd  = vtkMRMLBSplineTransformNode::SafeDownCast(nd);
-  gtnd  = vtkMRMLGridTransformNode::SafeDownCast(nd);
   fbnd  = vtkMRMLDisplayableNode::SafeDownCast(nd);
   cnd = vtkMRMLColorTableNode::SafeDownCast(nd);
   dand = vtkMRMLDoubleArrayNode::SafeDownCast(nd);
@@ -1030,7 +1021,7 @@ void vtkSlicerApplicationLogic::ProcessReadNodeData(ReadDataRequest& req)
           fson->Delete();
           }
         }
-    else if (ltnd || btnd || gtnd || tnd)
+    else if (tnd)
       {
       // Load a transform node
 
@@ -1205,7 +1196,7 @@ void vtkSlicerApplicationLogic::ProcessReadNodeData(ReadDataRequest& req)
       disp->SetAndObserveColorNodeID("vtkMRMLFreeSurferProceduralColorNodeRedGreen");
       }
     }
-  else if (ltnd || btnd || gtnd || tnd)
+  else if (tnd)
     {
     // Linear transform node
     // (no display node)

--- a/Base/Logic/vtkSlicerFiducialsLogic.cxx
+++ b/Base/Logic/vtkSlicerFiducialsLogic.cxx
@@ -11,11 +11,11 @@
 #include "vtkSlicerFiducialsLogic.h"
 
 // MRML includes
-#include "vtkMRMLLinearTransformNode.h"
 #include "vtkMRMLFiducialListNode.h"
 #include "vtkMRMLScene.h"
 #include "vtkMRMLSelectionNode.h"
 #include "vtkMRMLStorageNode.h"
+#include "vtkMRMLTransformNode.h"
 
 // VTK includes
 #include <vtkMatrix4x4.h>
@@ -187,10 +187,9 @@ int vtkSlicerFiducialsLogic::AddFiducialPicked (float x, float y, float z, int s
   vtkMRMLTransformNode* tnode = flist->GetParentTransformNode();
   vtkNew<vtkMatrix4x4> transformToWorld;
   transformToWorld->Identity();
-  if (tnode != NULL && tnode->IsLinear())
+  if (tnode != NULL && tnode->IsTransformToWorldLinear())
     {
-    vtkMRMLLinearTransformNode *lnode = vtkMRMLLinearTransformNode::SafeDownCast(tnode);
-    lnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
+    tnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
     }
   // will convert by the inverted parent transform
   transformToWorld->Invert();

--- a/Libs/MRML/Core/Testing/vtkMRMLNonlinearTransformNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLNonlinearTransformNodeTest1.cxx
@@ -229,7 +229,6 @@ bool TestCompositeTransform(const char *filename)
   hardeningTransform->Update();
 
   bsplineTransformNode->ApplyTransform(hardeningTransform.GetPointer());
-
   bsplineTransformNode->SetAndObserveTransformNodeID(NULL);
 
   // Get transforms from hardened transform
@@ -238,12 +237,12 @@ bool TestCompositeTransform(const char *filename)
   vtkNew<vtkGeneralTransform> transformFromWorldAfterHardening;
   bsplineTransformNode->GetTransformFromWorld(transformFromWorldAfterHardening.GetPointer());
 
-  // Test if the copied transform gives the same results as the original
+  // Test if the hardened transform gives the same results as the original
   double outpCopy[3] = {0,0,0};
   transformToWorldAfterHardening->TransformPoint(inp, outpCopy);
   if (fabs(outpCopy[0]-outp[0]) > 0.1 || fabs(outpCopy[1]-outp[1]) > 0.1 || fabs(outpCopy[2]-outp[2]) > 0.1)
     {
-    std::cout << __LINE__ << ": TestCompositeTransform failed" << std::endl;
+    std::cout << __LINE__ << ": TestCompositeTransform harden failed" << std::endl;
     return false;
     }
 
@@ -252,9 +251,39 @@ bool TestCompositeTransform(const char *filename)
   transformFromWorldAfterHardening->TransformPoint(outpCopy, outpInvCopy);
   if (fabs(outpInvCopy[0]-outpInv[0]) > 0.1 || fabs(outpInvCopy[1]-outpInv[1]) > 0.1 || fabs(outpInvCopy[2]-outpInv[2]) > 0.1)
     {
-    std::cout << __LINE__ << ": TestCompositeTransform failed" << std::endl;
+    std::cout << __LINE__ << ": TestCompositeTransform harden failed" << std::endl;
     return false;
     }
+
+
+  // Test if transform to world is the same after splitting
+
+  bsplineTransformNode->Split();
+
+  // Get transforms from split transform
+  vtkNew<vtkGeneralTransform> transformToWorldAfterSplitting;
+  bsplineTransformNode->GetTransformToWorld(transformToWorldAfterSplitting.GetPointer());
+  vtkNew<vtkGeneralTransform> transformFromWorldAfterSplitting;
+  bsplineTransformNode->GetTransformFromWorld(transformFromWorldAfterSplitting.GetPointer());
+
+  // Test if the split transform gives the same results as the original
+  double outpSplit[3] = {0,0,0};
+  transformToWorldAfterSplitting->TransformPoint(inp, outpSplit);
+  if (fabs(outpSplit[0]-outp[0]) > 0.1 || fabs(outpSplit[1]-outp[1]) > 0.1 || fabs(outpSplit[2]-outp[2]) > 0.1)
+    {
+    std::cout << __LINE__ << ": TestCompositeTransform split failed" << std::endl;
+    return false;
+    }
+
+  // Test if the inverse transform moves back the point to its original position
+  double outpInvSplit[3] = {-100, -100, -100};
+  transformFromWorldAfterSplitting->TransformPoint(outpSplit, outpInvSplit);
+  if (fabs(outpInvSplit[0]-outpInv[0]) > 0.1 || fabs(outpInvSplit[1]-outpInv[1]) > 0.1 || fabs(outpInvSplit[2]-outpInv[2]) > 0.1)
+    {
+    std::cout << __LINE__ << ": TestCompositeTransform split failed" << std::endl;
+    return false;
+    }
+
 
   // Cleanup
   scene->Clear(1);

--- a/Libs/MRML/Core/vtkMRMLFiducialListNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLFiducialListNode.cxx
@@ -16,8 +16,8 @@ Version:   $Revision: 1.3 $
 #include "vtkMRMLFiducial.h"
 #include "vtkMRMLFiducialListNode.h"
 #include "vtkMRMLFiducialListStorageNode.h"
-#include "vtkMRMLLinearTransformNode.h"
 #include "vtkMRMLScene.h"
+#include "vtkMRMLTransformNode.h"
 
 // VTK includes
 #include <vtkAbstractTransform.h>
@@ -737,10 +737,9 @@ int vtkMRMLFiducialListNode::SetNthFiducialXYZWorld(int n, float x, float y, flo
   vtkMRMLTransformNode* tnode = this->GetParentTransformNode();
   vtkNew<vtkMatrix4x4> transformToWorld;
   transformToWorld->Identity();
-  if (tnode != NULL && tnode->IsLinear())
+  if (tnode != NULL && tnode->IsTransformToWorldLinear())
     {
-    vtkMRMLLinearTransformNode *lnode = vtkMRMLLinearTransformNode::SafeDownCast(tnode);
-    lnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
+    tnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
     }
   // convert by the inverted parent transform
   transformToWorld->Invert();
@@ -789,10 +788,9 @@ int vtkMRMLFiducialListNode::GetNthFiducialXYZWorld(int n, double *worldxyz)
   vtkMRMLTransformNode* tnode = this->GetParentTransformNode();
   vtkNew<vtkMatrix4x4> transformToWorld;
   transformToWorld->Identity();
-  if (tnode != NULL && tnode->IsLinear())
+  if (tnode != NULL && tnode->IsTransformToWorldLinear())
     {
-    vtkMRMLLinearTransformNode *lnode = vtkMRMLLinearTransformNode::SafeDownCast(tnode);
-    lnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
+    tnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
     }
   // convert by the parent transform
   double  xyzw[4];

--- a/Libs/MRML/Core/vtkMRMLLinearTransformNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLLinearTransformNode.cxx
@@ -16,9 +16,7 @@ Version:   $Revision: 1.14 $
 #include "vtkMRMLLinearTransformNode.h"
 
 // VTK includes
-#include <vtkCommand.h>
-#include <vtkGeneralTransform.h>
-#include <vtkTransform.h>
+#include <vtkMatrix4x4.h>
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
 
@@ -31,21 +29,13 @@ vtkMRMLNodeNewMacro(vtkMRMLLinearTransformNode);
 //----------------------------------------------------------------------------
 vtkMRMLLinearTransformNode::vtkMRMLLinearTransformNode()
 {
-  this->CachedMatrixTransformToParent=vtkMatrix4x4::New();
-  this->CachedMatrixTransformFromParent=vtkMatrix4x4::New();
-
   vtkNew<vtkMatrix4x4> matrix;
   this->SetMatrixTransformToParent(matrix.GetPointer());
-
 }
 
 //----------------------------------------------------------------------------
 vtkMRMLLinearTransformNode::~vtkMRMLLinearTransformNode()
 {
-  this->CachedMatrixTransformToParent->Delete();
-  this->CachedMatrixTransformToParent=NULL;
-  this->CachedMatrixTransformFromParent->Delete();
-  this->CachedMatrixTransformFromParent=NULL;
 }
 
 //----------------------------------------------------------------------------
@@ -55,27 +45,30 @@ void vtkMRMLLinearTransformNode::WriteXML(ostream& of, int nIndent)
 
   vtkIndent indent(nIndent);
 
-  vtkNew<vtkMatrix4x4> matrix;
-  GetMatrixTransformToParent(matrix.GetPointer());
-
-  std::stringstream ss;
-  for (int row=0; row<4; row++)
+  if (this->IsLinear())
     {
-    for (int col=0; col<4; col++)
+    // Only write the matrix to the scene if the object stores a linear transform
+    vtkNew<vtkMatrix4x4> matrix;
+    this->GetMatrixTransformToParent(matrix.GetPointer());
+
+    std::stringstream ss;
+    for (int row=0; row<4; row++)
       {
-      ss << matrix->GetElement(row, col);
-      if (!(row==3 && col==3))
+      for (int col=0; col<4; col++)
+        {
+        ss << matrix->GetElement(row, col);
+        if (!(row==3 && col==3))
+          {
+          ss << " ";
+          }
+        }
+      if ( row != 3 )
         {
         ss << " ";
         }
       }
-    if ( row != 3 )
-      {
-      ss << " ";
-      }
+    of << indent << " matrixTransformToParent=\"" << ss.str() << "\"";
     }
-  of << indent << " matrixTransformToParent=\"" << ss.str() << "\"";
-
 }
 
 //----------------------------------------------------------------------------
@@ -166,264 +159,26 @@ void vtkMRMLLinearTransformNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   Superclass::PrintSelf(os,indent);
 
-  vtkNew<vtkMatrix4x4> toParentMatrix;
-  this->GetMatrixTransformToParent(toParentMatrix.GetPointer());
-
-  os << indent << "MatrixTransformToParent: " << "\n";
-  for (int row=0; row<4; row++)
+  if (this->IsLinear())
     {
-    for (int col=0; col<4; col++)
-      {
-      os << toParentMatrix->GetElement(row, col);
-      if (!(row==3 && col==3))
-        {
-        os << " ";
-        }
-      else
-        {
-        os << "\n";
-        }
-      } // for (int col
-    } // for (int row
-}
-
-
-//----------------------------------------------------------------------------
-int vtkMRMLLinearTransformNode::GetMatrixTransformToParent(vtkMatrix4x4* matrix)
-{
-  if (matrix==NULL)
-    {
-    vtkErrorMacro("vtkMRMLLinearTransformNode::GetMatrixTransformToParent failed: matrix is invalid");
-    return 0;
-    }
-  vtkTransform* transform=vtkTransform::SafeDownCast(GetTransformToParentAs("vtkTransform"));
-  if (transform==NULL)
-    {
-    matrix->Identity();
-    return 0;
-    }
-  transform->GetMatrix(matrix);
-  return 1;
-}
-
-//----------------------------------------------------------------------------
-int vtkMRMLLinearTransformNode::GetMatrixTransformFromParent(vtkMatrix4x4* matrix)
-{
-  vtkNew<vtkMatrix4x4> transformToParentMatrix;
-  int result = GetMatrixTransformToParent(transformToParentMatrix.GetPointer());
-  vtkMatrix4x4::Invert(transformToParentMatrix.GetPointer(), matrix);
-  return result;
-}
-
-//----------------------------------------------------------------------------
-int  vtkMRMLLinearTransformNode::GetMatrixTransformToWorld(vtkMatrix4x4* transformToWorld)
-{
-  if (this->IsTransformToWorldLinear() != 1)
-    {
-    vtkWarningMacro("Failed to retrieve matrix to world from transform, the requested transform is not linear");
-    transformToWorld->Identity();
-    return 0;
-    }
-
-  // vtkMatrix4x4::Multiply4x4 computes the result in a separate buffer, so it is safe to use the input as output as well
-  vtkNew<vtkMatrix4x4> matrixTransformToParent;
-  if (!this->GetMatrixTransformToParent(matrixTransformToParent.GetPointer()))
-    {
-    vtkErrorMacro("Failed to retrieve matrix from linear transform");
-    transformToWorld->Identity();
-    return 0;
-    }
-  vtkMatrix4x4::Multiply4x4(matrixTransformToParent.GetPointer(), transformToWorld, transformToWorld);
-
-  vtkMRMLTransformNode *parent = this->GetParentTransformNode();
-  if (parent != NULL)
-    {
-    vtkMRMLLinearTransformNode *lparent = vtkMRMLLinearTransformNode::SafeDownCast(parent);
-    if (lparent)
-      {
-      return (lparent->GetMatrixTransformToWorld(transformToWorld));
-      }
-    else
-      {
-      vtkErrorMacro("vtkMRMLLinearTransformNode::GetMatrixTransformToWorld failed: expected parent linear transform");
-      transformToWorld->Identity();
-      return 0;
-      }
-    }
-  return 1;
-}
-
-//----------------------------------------------------------------------------
-int  vtkMRMLLinearTransformNode::GetMatrixTransformToNode(vtkMRMLTransformNode* node,
-                                                          vtkMatrix4x4* transformToNode)
-{
-  if (node == NULL)
-    {
-    return this->GetMatrixTransformToWorld(transformToNode);
-    }
-  if (this->IsTransformToNodeLinear(node) != 1)
-    {
-    transformToNode->Identity();
-    return 0;
-    }
-
-  if (this->IsTransformNodeMyParent(node))
-    {
-    vtkMRMLTransformNode *parent = this->GetParentTransformNode();
     vtkNew<vtkMatrix4x4> toParentMatrix;
     this->GetMatrixTransformToParent(toParentMatrix.GetPointer());
-    if (parent != NULL)
+
+    os << indent << "MatrixTransformToParent: " << "\n";
+    for (int row=0; row<4; row++)
       {
-      vtkMatrix4x4::Multiply4x4(toParentMatrix.GetPointer(), transformToNode, transformToNode);
-      if (strcmp(parent->GetID(), node->GetID()) )
+      for (int col=0; col<4; col++)
         {
-        this->GetMatrixTransformToNode(node, transformToNode);
-        }
-      }
-    else
-      {
-      vtkMatrix4x4::Multiply4x4(toParentMatrix.GetPointer(), transformToNode, transformToNode);
-      }
+        os << toParentMatrix->GetElement(row, col);
+        if (!(row==3 && col==3))
+          {
+          os << " ";
+          }
+        else
+          {
+          os << "\n";
+          }
+        } // for (int col
+      } // for (int row
     }
-  else if (this->IsTransformNodeMyChild(node))
-    {
-    vtkMRMLLinearTransformNode *lnode = dynamic_cast <vtkMRMLLinearTransformNode *> (node);
-    vtkMRMLLinearTransformNode *parent = dynamic_cast <vtkMRMLLinearTransformNode *> (node->GetParentTransformNode());
-    vtkNew<vtkMatrix4x4> toParentMatrix;
-    lnode->GetMatrixTransformToParent(toParentMatrix.GetPointer());
-    if (parent != NULL)
-      {
-      vtkMatrix4x4::Multiply4x4(toParentMatrix.GetPointer(), transformToNode, transformToNode);
-      if (strcmp(parent->GetID(), this->GetID()) )
-        {
-        this->GetMatrixTransformToNode(this, transformToNode);
-        }
-      }
-    else
-      {
-      vtkMatrix4x4::Multiply4x4(toParentMatrix.GetPointer(), transformToNode, transformToNode);
-      }
-    }
-  else
-    {
-    this->GetMatrixTransformToWorld(transformToNode);
-    vtkNew<vtkMatrix4x4> transformToWorld2;
-
-    node->GetMatrixTransformToWorld(transformToWorld2.GetPointer());
-    transformToWorld2->Invert();
-
-    vtkMatrix4x4::Multiply4x4(transformToWorld2.GetPointer(), transformToNode, transformToNode);
-    }
-  return 1;
-}
-
-
-//----------------------------------------------------------------------------
-void vtkMRMLLinearTransformNode::SetMatrixTransformToParent(vtkMatrix4x4 *matrix)
-{
-  // Temporarily disable all Modified and TransformModified events to make sure that
-  // the operations are performed without interruption.
-  int oldTransformModify=this->StartTransformModify();
-  int oldModify=this->StartModify();
-
-  vtkTransform* currentTransform = NULL;
-  if (this->TransformToParent!=NULL)
-    {
-    currentTransform = vtkTransform::SafeDownCast(GetTransformToParentAs("vtkTransform"));
-    }
-
-  if (currentTransform)
-    {
-    // Reset InverseFlag (in case an external module has changed it)
-    if (currentTransform->GetInverseFlag())
-      {
-      currentTransform->Inverse();
-      }
-    // Set matrix
-    if (matrix)
-      {
-      currentTransform->SetMatrix(matrix);
-      }
-    else
-      {
-      currentTransform->Identity();
-      }
-    }
-  else
-    {
-    // Transform does not exist or not the right type, replace it with a new one
-    vtkNew<vtkTransform> transform;
-    if (matrix)
-      {
-      transform->SetMatrix(matrix);
-      }
-    this->SetAndObserveTransformToParent(transform.GetPointer());
-    }
-
-  this->TransformToParent->Modified();
-  this->EndModify(oldModify);
-  this->EndTransformModify(oldTransformModify);
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLLinearTransformNode::SetMatrixTransformFromParent(vtkMatrix4x4 *matrix)
-{
-  vtkNew<vtkMatrix4x4> inverseMatrix;
-  vtkMatrix4x4::Invert(matrix, inverseMatrix.GetPointer());
-  SetMatrixTransformToParent(inverseMatrix.GetPointer());
-}
-
-//----------------------------------------------------------------------------
-bool vtkMRMLLinearTransformNode::CanApplyNonLinearTransforms()const
-{
-  return true;
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLLinearTransformNode::ApplyTransformMatrix(vtkMatrix4x4* transformMatrix)
-{
-  if (transformMatrix==NULL)
-    {
-    vtkErrorMacro("vtkMRMLLinearTransformNode::ApplyTransformMatrix failed: input transform is invalid");
-    return;
-    }
-  // vtkMatrix4x4::Multiply4x4 computes the output in an internal buffer and then
-  // copies the result to the output matrix, therefore it is safe to use
-  // one of the input matrices as output
-  vtkNew<vtkMatrix4x4> matrixToParent;
-  this->GetMatrixTransformToParent(matrixToParent.GetPointer());
-  vtkMatrix4x4::Multiply4x4(transformMatrix, matrixToParent.GetPointer(), matrixToParent.GetPointer());
-  SetMatrixTransformToParent(matrixToParent.GetPointer());
-}
-
-// Deprecated methods, kept temporarily for compatibility with extensions that are not yet updated
-
-//----------------------------------------------------------------------------
-void vtkMRMLLinearTransformNode::SetAndObserveMatrixTransformToParent(vtkMatrix4x4 *matrix)
-{
-  vtkWarningMacro("vtkMRMLLinearTransformNode::SetAndObserveMatrixTransformToParent method is deprecated. Use vtkMRMLLinearTransformNode::SetMatrixTransformToParent instead");
-  SetMatrixTransformToParent(matrix);
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLLinearTransformNode::SetAndObserveMatrixTransformFromParent(vtkMatrix4x4 *matrix)
-{
-  vtkWarningMacro("vtkMRMLLinearTransformNode::SetAndObserveMatrixTransformFromParent method is deprecated. Use vtkMRMLLinearTransformNode::SetMatrixTransformFromParent instead");
-  SetMatrixTransformFromParent(matrix);
-}
-
-//----------------------------------------------------------------------------
-vtkMatrix4x4* vtkMRMLLinearTransformNode::GetMatrixTransformToParent()
-{
-  vtkWarningMacro("vtkMRMLLinearTransformNode::GetMatrixTransformToParent() method is deprecated. Use vtkMRMLLinearTransformNode::GetMatrixTransformToParent(vtkMatrix4x4*) instead");
-  GetMatrixTransformToParent(this->CachedMatrixTransformToParent);
-  return this->CachedMatrixTransformToParent;
-}
-
-//----------------------------------------------------------------------------
-vtkMatrix4x4* vtkMRMLLinearTransformNode::GetMatrixTransformFromParent()
-{
-  vtkWarningMacro("vtkMRMLLinearTransformNode::GetMatrixTransformFromParent() method is deprecated. Use vtkMRMLLinearTransformNode::GetMatrixTransformFromParent(vtkMatrix4x4*) instead");
-  GetMatrixTransformFromParent(this->CachedMatrixTransformFromParent);
-  return this->CachedMatrixTransformFromParent;
 }

--- a/Libs/MRML/Core/vtkMRMLLinearTransformNode.h
+++ b/Libs/MRML/Core/vtkMRMLLinearTransformNode.h
@@ -54,82 +54,17 @@ class VTK_MRML_EXPORT vtkMRMLLinearTransformNode : public vtkMRMLTransformNode
   virtual const char* GetNodeTagName() {return "LinearTransform";};
 
   ///
-  /// 1 if transfrom is linear, 0 otherwise
-  virtual int IsLinear() {return 1;};
-
-  ///
-  /// Get the vtkMatrix4x4 transform of this node to parent node
-  /// Returns 0 if the transform is undefined or there is an error.
-  virtual int GetMatrixTransformToParent(vtkMatrix4x4* matrix);
-
-  ///
-  /// Get the vtkMatrix4x4 transform of this node from parent node
-  /// Returns 0 if the transform is undefined or there is an error.
-  virtual int GetMatrixTransformFromParent(vtkMatrix4x4* matrix);
-
-  ///
-  /// Set a new matrix transform of this node to parent node.
-  /// Invokes a TransformModified event (does not invoke Modified).
-  void SetMatrixTransformToParent(vtkMatrix4x4 *matrix);
-
-  ///
-  /// Set a new matrix transform of this node from parent node.
-  /// Invokes a TransformModified event (does not invoke Modified).
-  void SetMatrixTransformFromParent(vtkMatrix4x4 *matrix);
-
-  ///
-  /// Get concatenated transforms to the top
-  virtual int  GetMatrixTransformToWorld(vtkMatrix4x4* transformToWorld);
-
-  ///
-  /// Get concatenated transforms  bwetween nodes
-  virtual int  GetMatrixTransformToNode(vtkMRMLTransformNode* node,
-                                        vtkMatrix4x4* transformToNode);
-
-  virtual bool CanApplyNonLinearTransforms()const;
-  virtual void ApplyTransformMatrix(vtkMatrix4x4* transformMatrix);
-
-  ///
   /// Create default storage node or NULL if does not have one
   virtual vtkMRMLStorageNode* CreateDefaultStorageNode()
     {
     return Superclass::CreateDefaultStorageNode();
     };
 
-    ///
-  /// Set a new matrix transform of this node to parent node.
-  /// Deprecated! Use SetMatrixTransformToParent instead.
-  void SetAndObserveMatrixTransformToParent(vtkMatrix4x4 *matrix);
-
-  ///
-  /// Set a new matrix transform of this node from parent node.
-  /// Deprecated! Use SetMatrixTransformToParent instead.
-  void SetAndObserveMatrixTransformFromParent(vtkMatrix4x4 *matrix);
-
-  ///
-  /// Set a new matrix transform of this node to parent node.
-  /// Deprecated! Use GetMatrixTransformToParent(vtkMatrix4x4*) instead.
-  /// The method returns a cached copy of the transform, so modification
-  /// of the matrix does not alter the transform node.
-  vtkMatrix4x4* GetMatrixTransformToParent();
-
-  ///
-  /// Set a new matrix transform of this node from parent node.
-  /// Deprecated! Use GetMatrixTransformFromParent(vtkMatrix4x4*) instead.
-  /// The method returns a cached copy of the transform, so modification
-  /// of the matrix does not alter the transform node.
-  vtkMatrix4x4* GetMatrixTransformFromParent();
-
 protected:
   vtkMRMLLinearTransformNode();
   ~vtkMRMLLinearTransformNode();
   vtkMRMLLinearTransformNode(const vtkMRMLLinearTransformNode&);
   void operator=(const vtkMRMLLinearTransformNode&);
-
-  /// These variables are only for supporting the deprecated
-  /// GetMatrixTransformToParent and GetMatrixFromParent methods
-  vtkMatrix4x4* CachedMatrixTransformToParent;
-  vtkMatrix4x4* CachedMatrixTransformFromParent;
 };
 
 #endif

--- a/Libs/MRML/Core/vtkMRMLROINode.cxx
+++ b/Libs/MRML/Core/vtkMRMLROINode.cxx
@@ -9,7 +9,7 @@
 #include "vtkMath.h"
 
 #include "vtkMRMLROINode.h"
-#include "vtkMRMLLinearTransformNode.h"
+#include "vtkMRMLTransformNode.h"
 
 //----------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLROINode);
@@ -503,12 +503,11 @@ void vtkMRMLROINode::GetTransformedPlanes(vtkPlanes *planes)
   points->Delete();
 
   vtkMRMLTransformNode* tnode = this->GetParentTransformNode();
-  if (tnode != NULL) // && tnode->IsLinear())
+  if (tnode != NULL) // && tnode->IsTransformToWorldLinear())
     {
     //vtkMatrix4x4* transformToWorld = vtkMatrix4x4::New();
     //transformToWorld->Identity();
-    //vtkMRMLLinearTransformNode *lnode = vtkMRMLLinearTransformNode::SafeDownCast(tnode);
-    //lnode->GetMatrixTransformToWorld(transformToWorld);
+    //tnode->GetMatrixTransformToWorld(transformToWorld);
 
     vtkGeneralTransform *transform = vtkGeneralTransform::New();
     tnode->GetTransformFromWorld(transform);

--- a/Libs/MRML/Core/vtkMRMLTransformNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.cxx
@@ -15,6 +15,9 @@ Version:   $Revision: 1.14 $
 #include "vtkMRMLTransformNode.h"
 
 // MRML includes
+#include "vtkMRMLBSplineTransformNode.h"
+#include "vtkMRMLGridTransformNode.h"
+#include "vtkMRMLLinearTransformNode.h"
 #include "vtkMRMLScene.h"
 #include "vtkMRMLTransformStorageNode.h"
 #include "vtkMRMLTransformDisplayNode.h"
@@ -27,9 +30,11 @@ Version:   $Revision: 1.14 $
 #include <vtkCollectionIterator.h>
 #include <vtkGeneralTransform.h>
 #include <vtkImageData.h>
+#include <vtkLinearTransform.h>
 #include <vtkHomogeneousTransform.h>
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
+#include <vtkTransform.h>
 
 // STD includes
 #include <sstream>
@@ -46,6 +51,9 @@ vtkMRMLTransformNode::vtkMRMLTransformNode()
   this->ReadAsTransformToParent=0;
   this->DisableTransformModifiedEvent=0;
   this->TransformModifiedEventPending=0;
+
+  this->CachedMatrixTransformToParent=vtkMatrix4x4::New();
+  this->CachedMatrixTransformFromParent=vtkMatrix4x4::New();
 }
 
 //----------------------------------------------------------------------------
@@ -53,6 +61,11 @@ vtkMRMLTransformNode::~vtkMRMLTransformNode()
 {
   vtkSetAndObserveMRMLObjectMacro(this->TransformToParent, NULL);
   vtkSetAndObserveMRMLObjectMacro(this->TransformFromParent, NULL);
+
+  this->CachedMatrixTransformToParent->Delete();
+  this->CachedMatrixTransformToParent=NULL;
+  this->CachedMatrixTransformFromParent->Delete();
+  this->CachedMatrixTransformFromParent=NULL;
 }
 
 //----------------------------------------------------------------------------
@@ -332,7 +345,7 @@ vtkAbstractTransform* vtkMRMLTransformNode::GetTransformFromParent()
 //----------------------------------------------------------------------------
 int  vtkMRMLTransformNode::IsTransformToWorldLinear()
 {
-  if (this->IsLinear() == 0)
+  if (!this->IsLinear())
     {
     return 0;
     }
@@ -560,44 +573,118 @@ void vtkMRMLTransformNode::ApplyTransform(vtkAbstractTransform* transform)
     return;
     }
 
-  vtkAbstractTransform* transformCopy=transform->MakeTransform();
-  DeepCopyTransform(transformCopy, transform);
+  // We need the current transform to be a vtkGeneralTransform, which can store all the transform components.
+  // (if the current transform is already a general transform then we can just use that, otherwise we convert)
+  // We arbitrarily pick the ToParent transform to store the new composited transform.
+  vtkAbstractTransform* oldTransformToParent = GetTransformToParent();
+  vtkSmartPointer<vtkGeneralTransform> transformToParentGeneral = vtkGeneralTransform::SafeDownCast(oldTransformToParent);
+  if (transformToParentGeneral==NULL)
+    {
+    transformToParentGeneral = vtkSmartPointer<vtkGeneralTransform>::New();
+    transformToParentGeneral->Concatenate(oldTransformToParent);
+    }
 
-  if (this->TransformToParent)
+  // Add new transform components
+  vtkSmartPointer<vtkAbstractTransform> transformCopy=vtkSmartPointer<vtkAbstractTransform>::Take(transform->MakeTransform());
+  DeepCopyTransform(transformCopy, transform);
+  // Flatten the transform list that will be applied to make the resulting general transform simpler
+  // (have a simple list instead of a complex hierarchy)
+  vtkNew<vtkCollection> transformCopyList;
+  FlattenGeneralTransform(transformCopyList.GetPointer(), transformCopy);
+  // Add components
+  transformToParentGeneral->PostMultiply();
+  for (int transformComponentIndex = transformCopyList->GetNumberOfItems()-1; transformComponentIndex>=0; transformComponentIndex--)
     {
-    vtkGeneralTransform* transformToParentGeneral=vtkGeneralTransform::SafeDownCast(this->TransformToParent);
-    if (transformToParentGeneral==NULL)
+    vtkAbstractTransform* transformComponent = vtkAbstractTransform::SafeDownCast(transformCopyList->GetItemAsObject(transformComponentIndex));
+    transformToParentGeneral->Concatenate(transformComponent);
+    }
+
+  // Save the new transform
+  SetAndObserveTransformToParent(transformToParentGeneral);
+}
+
+//-----------------------------------------------------------------------------
+int vtkMRMLTransformNode::Split()
+{
+  if (!IsComposite())
+    {
+    // not composite, cannot split
+    return 0;
+    }
+  vtkNew<vtkCollection> transformComponentList;
+  vtkAbstractTransform* transformToParent = this->GetTransformToParent();
+  if (transformToParent==NULL)
+    {
+    // no transform available, cannot split
+    return 0;
+    }
+  FlattenGeneralTransform(transformComponentList.GetPointer(), transformToParent);
+  int numberOfTransformComponents = transformComponentList->GetNumberOfItems();
+  if (numberOfTransformComponents<1)
+    {
+    // no items, nothing to split
+    return 0;
+    }
+  // If number of items is 1 we still continue, in this case we simplify the transform
+  // (as one transform can be in a general transform hierarchy)
+  vtkMRMLTransformNode* parentTransformNode = this->GetParentTransformNode();
+  vtkAbstractTransform* transformCopyComponent = NULL;
+  for (int transformComponentIndex = numberOfTransformComponents-1; transformComponentIndex>=0; transformComponentIndex--)
+    {
+    vtkAbstractTransform* transformComponent = vtkAbstractTransform::SafeDownCast(transformComponentList->GetItemAsObject(transformComponentIndex));
+    vtkSmartPointer<vtkMRMLTransformNode> transformComponentNode;
+    // Create a new transform node if for all transforms (parent transforms) but the last (the transform that is being split)
+    if (transformComponentIndex>0)
       {
-      // we need to convert this to a general transform
-      vtkNew<vtkGeneralTransform> generalTransform;
-      generalTransform->Concatenate(this->TransformToParent);
-      vtkSetAndObserveMRMLObjectMacro(this->TransformToParent, generalTransform.GetPointer());
-      transformToParentGeneral=generalTransform.GetPointer();
+      // Create a new transform node with the most suitable type.
+      // The generic vtkMRMLTransformNode could handle everything but at a couple of places
+      // the class type of the transform node is still used. When vtkMRMLLinearTransformNode, vtkMRMLBSplineTransformNode, and
+      // vtkMRMLGridTransformNode classes will be removed then we can simply create a vtkMRMLTransformNode regardless the VTK transform type.
+      if (transformComponent->IsA("vtkLinearTransform"))
+        {
+        transformComponentNode = vtkSmartPointer<vtkMRMLLinearTransformNode>::New();
+        }
+      else if (transformComponent->IsA("vtkBSplineTransform"))
+        {
+        transformComponentNode = vtkSmartPointer<vtkMRMLBSplineTransformNode>::New();
+        }
+      else if (transformComponent->IsA("vtkGridTransform"))
+        {
+        transformComponentNode = vtkSmartPointer<vtkMRMLGridTransformNode>::New();
+        }
+      else
+        {
+        transformComponentNode = vtkSmartPointer<vtkMRMLTransformNode>::New();
+        }
+      std::string baseName = std::string(this->GetName())+"_Component";
+      std::string uniqueName = this->GetScene()->GenerateUniqueName(baseName.c_str());
+      transformComponentNode->SetName(uniqueName.c_str());
+      this->GetScene()->AddNode(transformComponentNode.GetPointer());
       }
-    transformToParentGeneral->Concatenate(transformCopy);
-    }
-  else if (this->TransformFromParent)
-    {
-    vtkGeneralTransform* transformFromParentGeneral=vtkGeneralTransform::SafeDownCast(this->TransformFromParent);
-    if (transformFromParentGeneral==NULL)
+    else
       {
-      // we need to convert this to a general transform
-      vtkNew<vtkGeneralTransform> generalTransform;
-      generalTransform->Concatenate(this->TransformFromParent);
-      vtkSetAndObserveMRMLObjectMacro(this->TransformFromParent, generalTransform.GetPointer());
-      transformFromParentGeneral=generalTransform.GetPointer();
+      transformComponentNode = this;
       }
-    transformFromParentGeneral->Inverse();
-    transformFromParentGeneral->PostMultiply();
-    transformFromParentGeneral->Concatenate(transformCopy);
-    transformFromParentGeneral->PreMultiply();
-    transformFromParentGeneral->Inverse();
+    vtkWarpTransform* warpTransformComponent = vtkWarpTransform::SafeDownCast(transformComponent);
+    // In case of non-linear transform set as to/from parent so that the transform will not be inverted
+    bool setAsTransformFromParent = false;
+    if (warpTransformComponent)
+      {
+      warpTransformComponent->Update(); // Update is needed bacause it refreshes the inverse flag (the flag may be out-of-date if the transform depends on its inverse)
+      setAsTransformFromParent = warpTransformComponent->GetInverseFlag();
+      }
+    if (setAsTransformFromParent)
+      {
+      transformComponentNode->SetAndObserveTransformFromParent(transformComponent->GetInverse());
+      }
+    else
+      {
+      transformComponentNode->SetAndObserveTransformToParent(transformComponent);
+      }
+    transformComponentNode->SetAndObserveTransformNodeID(parentTransformNode ? parentTransformNode->GetID() : NULL);
+    parentTransformNode=transformComponentNode.GetPointer();
     }
-  else
-    {
-    vtkSetAndObserveMRMLObjectMacro(this->TransformToParent, transformCopy);
-    }
-  transformCopy->Delete();
+  return 1;
 }
 
 //----------------------------------------------------------------------------
@@ -643,23 +730,131 @@ bool vtkMRMLTransformNode::GetModifiedSinceRead()
 }
 
 //----------------------------------------------------------------------------
-int  vtkMRMLTransformNode::GetMatrixTransformToWorld(vtkMatrix4x4* transformToWorld)
+int vtkMRMLTransformNode::GetMatrixTransformToParent(vtkMatrix4x4* matrix)
 {
-  // The fact that this method is called means that this is a non-linear transform,
-  // so we cannot return the transform as a matrix
-  transformToWorld->Identity();
-  return 0;
+  if (matrix==NULL)
+    {
+    vtkErrorMacro("vtkMRMLTransformNode::GetMatrixTransformToParent failed: matrix is invalid");
+    return 0;
+    }
+  vtkLinearTransform* transform=vtkLinearTransform::SafeDownCast(GetTransformToParentAs("vtkLinearTransform", false));
+  if (transform==NULL)
+    {
+    vtkWarningMacro("Failed to get transformation matrix because transform is not linear");
+    matrix->Identity();
+    return 0;
+    }
+  transform->GetMatrix(matrix);
+  return 1;
 }
 
 //----------------------------------------------------------------------------
-int  vtkMRMLTransformNode::GetMatrixTransformToNode(vtkMRMLTransformNode* vtkNotUsed(node),
-                                                          vtkMatrix4x4* transformToNode)
+int vtkMRMLTransformNode::GetMatrixTransformFromParent(vtkMatrix4x4* matrix)
 {
-  // The fact that this method is called means that this is a non-linear transform,
-  // so we cannot return the transform as a matrix
-  vtkWarningMacro("vtkMRMLTransformNode::GetMatrixTransformToNode failed: this is not a linear transform");
-  transformToNode->Identity();
-  return 0;
+  vtkNew<vtkMatrix4x4> transformToParentMatrix;
+  int result = GetMatrixTransformToParent(transformToParentMatrix.GetPointer());
+  vtkMatrix4x4::Invert(transformToParentMatrix.GetPointer(), matrix);
+  return result;
+}
+
+//----------------------------------------------------------------------------
+int  vtkMRMLTransformNode::GetMatrixTransformToWorld(vtkMatrix4x4* transformToWorld)
+{
+  if (!this->IsTransformToWorldLinear())
+    {
+    vtkWarningMacro("Failed to retrieve matrix to world from transform, the requested transform is not linear");
+    transformToWorld->Identity();
+    return 0;
+    }
+
+  // vtkMatrix4x4::Multiply4x4 computes the result in a separate buffer, so it is safe to use the input as output as well
+  vtkNew<vtkMatrix4x4> matrixTransformToParent;
+  if (!this->GetMatrixTransformToParent(matrixTransformToParent.GetPointer()))
+    {
+    vtkErrorMacro("Failed to retrieve matrix from linear transform");
+    transformToWorld->Identity();
+    return 0;
+    }
+  vtkMatrix4x4::Multiply4x4(matrixTransformToParent.GetPointer(), transformToWorld, transformToWorld);
+
+  vtkMRMLTransformNode *parent = this->GetParentTransformNode();
+  if (parent != NULL)
+    {
+    if (parent->IsLinear())
+      {
+      return (parent->GetMatrixTransformToWorld(transformToWorld));
+      }
+    else
+      {
+      vtkErrorMacro("vtkMRMLTransformNode::GetMatrixTransformToWorld failed: expected parent linear transform");
+      transformToWorld->Identity();
+      return 0;
+      }
+    }
+  return 1;
+}
+
+//----------------------------------------------------------------------------
+int  vtkMRMLTransformNode::GetMatrixTransformToNode(vtkMRMLTransformNode* node, vtkMatrix4x4* transformToNode)
+{
+  if (node == NULL)
+    {
+    return this->GetMatrixTransformToWorld(transformToNode);
+    }
+  if (!this->IsTransformToNodeLinear(node))
+    {
+    vtkErrorMacro("vtkMRMLTransformNode::GetMatrixTransformToNode failed: expected linear transforms between nodes");
+    transformToNode->Identity();
+    return 0;
+    }
+
+  if (this->IsTransformNodeMyParent(node))
+    {
+    vtkMRMLTransformNode *parent = this->GetParentTransformNode();
+    vtkNew<vtkMatrix4x4> toParentMatrix;
+    this->GetMatrixTransformToParent(toParentMatrix.GetPointer());
+    if (parent != NULL)
+      {
+      vtkMatrix4x4::Multiply4x4(toParentMatrix.GetPointer(), transformToNode, transformToNode);
+      if (strcmp(parent->GetID(), node->GetID()) )
+        {
+        this->GetMatrixTransformToNode(node, transformToNode);
+        }
+      }
+    else
+      {
+      vtkMatrix4x4::Multiply4x4(toParentMatrix.GetPointer(), transformToNode, transformToNode);
+      }
+    }
+  else if (this->IsTransformNodeMyChild(node))
+    {
+    vtkNew<vtkMatrix4x4> toParentMatrix;
+    node->GetMatrixTransformToParent(toParentMatrix.GetPointer());
+    vtkMRMLTransformNode *parent = vtkMRMLTransformNode::SafeDownCast(node->GetParentTransformNode());
+    if (parent != NULL)
+      {
+      vtkMatrix4x4::Multiply4x4(toParentMatrix.GetPointer(), transformToNode, transformToNode);
+      if (strcmp(parent->GetID(), this->GetID()) )
+        {
+        this->GetMatrixTransformToNode(this, transformToNode);
+        }
+      }
+    else
+      {
+      vtkMatrix4x4::Multiply4x4(toParentMatrix.GetPointer(), transformToNode, transformToNode);
+      }
+    }
+  else
+    {
+    this->GetMatrixTransformToWorld(transformToNode);
+    vtkNew<vtkMatrix4x4> transformToWorld2;
+
+    node->GetMatrixTransformToWorld(transformToWorld2.GetPointer());
+    transformToWorld2->Invert();
+
+    vtkMatrix4x4::Multiply4x4(transformToWorld2.GetPointer(), transformToNode, transformToNode);
+    }
+  return 1;
 }
 
 //----------------------------------------------------------------------------
@@ -943,7 +1138,11 @@ const char* vtkMRMLTransformNode::GetTransformInfo(vtkAbstractTransform* inputTr
         }
       ss << "Transform "<<i+1<<":";
       }
-    vtkObject* transform=transformList->GetItemAsObject(i);
+    vtkAbstractTransform* transform=vtkAbstractTransform::SafeDownCast(transformList->GetItemAsObject(i));
+    if (transform)
+      {
+      transform->Update();
+      }
 
     vtkHomogeneousTransform* linearTransform=vtkHomogeneousTransform::SafeDownCast(transform);
     vtkBSplineTransform* bsplineTransform=vtkBSplineTransform::SafeDownCast(transform);
@@ -1048,4 +1247,162 @@ const char* vtkMRMLTransformNode::GetTransformInfo(vtkAbstractTransform* inputTr
   ss << std::ends;
   this->TransformInfo=ss.str();
   return this->TransformInfo.c_str();
+}
+
+
+//----------------------------------------------------------------------------
+int vtkMRMLTransformNode::IsLinear()
+{
+  // Most often linear transform is a single vtkTransform stored in this->TransformToParent.
+  // Do a simple check for this specific case first to make this method as fast as possible.
+  if (this->TransformToParent!=NULL && this->TransformToParent->IsA("vtkLinearTransform"))
+    {
+    return 1;
+    }
+  if (this->TransformFromParent!=NULL && this->TransformFromParent->IsA("vtkLinearTransform"))
+    {
+    return 1;
+    }
+  // No transform means identity transform, which is a linear transform
+  if (this->TransformToParent==NULL && this->TransformFromParent==NULL)
+    {
+    return 1;
+    }
+  return 0;
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLTransformNode::IsComposite()
+{
+  if (this->TransformToParent!=NULL && this->TransformToParent->IsA("vtkGeneralTransform"))
+    {
+    return 1;
+    }
+  if (this->TransformFromParent!=NULL && this->TransformFromParent->IsA("vtkGeneralTransform"))
+    {
+    return 1;
+    }
+  return 0;
+}
+
+// Deprecated method - kept temporarily for compatibility with extensions that are not yet updated
+//----------------------------------------------------------------------------
+vtkMatrix4x4* vtkMRMLTransformNode::GetMatrixTransformToParent()
+{
+  vtkWarningMacro("vtkMRMLTransformNode::GetMatrixTransformToParent() method is deprecated. Use vtkMRMLTransformNode::GetMatrixTransformToParent(vtkMatrix4x4*) instead");
+  GetMatrixTransformToParent(this->CachedMatrixTransformToParent);
+  return this->CachedMatrixTransformToParent;
+}
+
+// Deprecated method - kept temporarily for compatibility with extensions that are not yet updated
+//----------------------------------------------------------------------------
+vtkMatrix4x4* vtkMRMLTransformNode::GetMatrixTransformFromParent()
+{
+  vtkWarningMacro("vtkMRMLTransformNode::GetMatrixTransformFromParent() method is deprecated. Use vtkMRMLTransformNode::GetMatrixTransformFromParent(vtkMatrix4x4*) instead");
+  GetMatrixTransformFromParent(this->CachedMatrixTransformFromParent);
+  return this->CachedMatrixTransformFromParent;
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLTransformNode::SetMatrixTransformToParent(vtkMatrix4x4 *matrix)
+{
+  if (!this->IsLinear())
+    {
+    vtkWarningMacro("Cannot set matrix, as vtkMRMLTransformNode contains a non-linear transform");
+    return 0;
+    }
+
+  // Temporarily disable all Modified and TransformModified events to make sure that
+  // the operations are performed without interruption.
+  int oldTransformModify=this->StartTransformModify();
+  int oldModify=this->StartModify();
+
+  vtkTransform* currentTransform = NULL;
+  if (this->TransformToParent!=NULL)
+    {
+    currentTransform = vtkTransform::SafeDownCast(GetTransformToParentAs("vtkTransform"));
+    }
+
+  if (currentTransform)
+    {
+    // Reset InverseFlag (in case an external module has changed it)
+    if (currentTransform->GetInverseFlag())
+      {
+      currentTransform->Inverse();
+      }
+    // Set matrix
+    if (matrix)
+      {
+      currentTransform->SetMatrix(matrix);
+      }
+    else
+      {
+      currentTransform->Identity();
+      }
+    }
+  else
+    {
+    // Transform does not exist or not the right type, replace it with a new one
+    vtkNew<vtkTransform> transform;
+    if (matrix)
+      {
+      transform->SetMatrix(matrix);
+      }
+    this->SetAndObserveTransformToParent(transform.GetPointer());
+    }
+
+  this->TransformToParent->Modified();
+  this->EndModify(oldModify);
+  this->EndTransformModify(oldTransformModify);
+  return 1;
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLTransformNode::SetMatrixTransformFromParent(vtkMatrix4x4 *matrix)
+{
+  vtkNew<vtkMatrix4x4> inverseMatrix;
+  vtkMatrix4x4::Invert(matrix, inverseMatrix.GetPointer());
+  return SetMatrixTransformToParent(inverseMatrix.GetPointer());
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLTransformNode::ApplyTransformMatrix(vtkMatrix4x4* transformMatrix)
+{
+  if (transformMatrix==NULL)
+    {
+    vtkErrorMacro("vtkMRMLTransformNode::ApplyTransformMatrix failed: input transform is invalid");
+    return;
+    }
+  if (!this->IsLinear())
+    {
+    // This object stores a non-linear transform, so we cannot merge the matrix with the existing transform, so
+    // concatenate the linear transform (defined by transformMatrix) instead.
+    vtkNew<vtkTransform> transform;
+    transform->SetMatrix(transformMatrix);
+    ApplyTransform(transform.GetPointer());
+    return;
+    }
+  // vtkMatrix4x4::Multiply4x4 computes the output in an internal buffer and then
+  // copies the result to the output matrix, therefore it is safe to use
+  // one of the input matrices as output
+  vtkNew<vtkMatrix4x4> matrixToParent;
+  this->GetMatrixTransformToParent(matrixToParent.GetPointer());
+  vtkMatrix4x4::Multiply4x4(transformMatrix, matrixToParent.GetPointer(), matrixToParent.GetPointer());
+  SetMatrixTransformToParent(matrixToParent.GetPointer());
+}
+
+// Deprecated method - kept temporarily for compatibility with extensions that are not yet updated
+//----------------------------------------------------------------------------
+int vtkMRMLTransformNode::SetAndObserveMatrixTransformToParent(vtkMatrix4x4 *matrix)
+{
+  vtkWarningMacro("vtkMRMLTransformNode::SetAndObserveMatrixTransformToParent method is deprecated. Use vtkMRMLTransformNode::SetMatrixTransformToParent instead");
+  return SetMatrixTransformToParent(matrix);
+}
+
+// Deprecated method - kept temporarily for compatibility with extensions that are not yet updated
+//----------------------------------------------------------------------------
+int vtkMRMLTransformNode::SetAndObserveMatrixTransformFromParent(vtkMatrix4x4 *matrix)
+{
+  vtkWarningMacro("vtkMRMLTransformNode::SetAndObserveMatrixTransformFromParent method is deprecated. Use vtkMRMLTransformNode::SetMatrixTransformFromParent instead");
+  return SetMatrixTransformFromParent(matrix);
 }

--- a/Libs/MRML/Core/vtkMRMLTransformableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformableNode.cxx
@@ -12,10 +12,12 @@ Version:   $Revision: 1.14 $
 
 =========================================================================auto=*/
 
+#include "vtkMRMLTransformableNode.h"
+
 // MRML includes
 #include "vtkEventBroker.h"
-#include "vtkMRMLLinearTransformNode.h"
 #include "vtkMRMLScene.h"
+#include "vtkMRMLTransformNode.h"
 
 // VTK includes
 #include <vtkCommand.h>
@@ -174,12 +176,11 @@ void vtkMRMLTransformableNode::TransformPointToWorld(const double in[4], double 
 {
   // get the nodes's transform node
   vtkMRMLTransformNode* tnode = this->GetParentTransformNode();
-  if (tnode != NULL && tnode->IsLinear())
+  if (tnode != NULL && tnode->IsTransformToWorldLinear())
     {
-    vtkMRMLLinearTransformNode *lnode = vtkMRMLLinearTransformNode::SafeDownCast(tnode);
     vtkMatrix4x4* transformToWorld = vtkMatrix4x4::New();
     transformToWorld->Identity();
-    lnode->GetMatrixTransformToWorld(transformToWorld);
+    tnode->GetMatrixTransformToWorld(transformToWorld);
     transformToWorld->MultiplyPoint(in, out);
     transformToWorld->Delete();
     }
@@ -201,12 +202,11 @@ void vtkMRMLTransformableNode::TransformPointFromWorld(const double in[4], doubl
 {
   // get the nodes's transform node
   vtkMRMLTransformNode* tnode = this->GetParentTransformNode();
-  if (tnode != NULL && tnode->IsLinear())
+  if (tnode != NULL && tnode->IsTransformToWorldLinear())
     {
-    vtkMRMLLinearTransformNode *lnode = vtkMRMLLinearTransformNode::SafeDownCast(tnode);
     vtkMatrix4x4* transformToWorld = vtkMatrix4x4::New();
     transformToWorld->Identity();
-    lnode->GetMatrixTransformToWorld(transformToWorld);
+    tnode->GetMatrixTransformToWorld(transformToWorld);
     transformToWorld->Invert();
     transformToWorld->MultiplyPoint(in, out);
     transformToWorld->Delete();

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
@@ -23,7 +23,6 @@
 #include <vtkEventBroker.h>
 #include <vtkMRMLDisplayableNode.h>
 #include <vtkMRMLDisplayNode.h>
-#include <vtkMRMLLinearTransformNode.h>
 #include <vtkMRMLModelDisplayNode.h>
 #include <vtkMRMLModelHierarchyNode.h>
 #include <vtkMRMLModelNode.h>
@@ -34,6 +33,7 @@
 #include <vtkMRMLViewNode.h>
 #include <vtkMRMLInteractionNode.h>
 #include <vtkMRMLSelectionNode.h>
+#include <vtkMRMLTransformNode.h>
 
 // VTK includes
 #include <vtkAlgorithmOutput.h>
@@ -907,7 +907,7 @@ void vtkMRMLModelDisplayableManager
   vtkMRMLTransformNode* tnode = displayableNode->GetParentTransformNode();
   vtkGeneralTransform *worldTransform = vtkGeneralTransform::New();
   worldTransform->Identity();
-  if (tnode != 0 && !tnode->IsLinear())
+  if (tnode != 0 && !tnode->IsTransformToWorldLinear())
     {
     hasNonLinearTransform = true;
     tnode->GetTransformToWorld(worldTransform);
@@ -1057,7 +1057,7 @@ void vtkMRMLModelDisplayableManager
         vtkMRMLTransformNode* tnode = displayableNode->GetParentTransformNode();
         // clipped model could be transformed
         // TODO: handle non-linear transforms
-        if (clipping == 0 || tnode == 0 || !tnode->IsLinear())
+        if (clipping == 0 || tnode == 0 || !tnode->IsTransformToWorldLinear())
           {
           continue;
           }
@@ -1513,10 +1513,9 @@ void vtkMRMLModelDisplayableManager::SetModelDisplayProperty(vtkMRMLDisplayableN
   vtkMRMLTransformNode* tnode = model->GetParentTransformNode();
 
   vtkNew<vtkMatrix4x4> matrixTransformToWorld;
-  if (tnode != 0 && tnode->IsLinear())
+  if (tnode != 0 && tnode->IsTransformToWorldLinear())
     {
-    vtkMRMLLinearTransformNode *lnode = vtkMRMLLinearTransformNode::SafeDownCast(tnode);
-    lnode->GetMatrixTransformToWorld(matrixTransformToWorld.GetPointer());
+    tnode->GetMatrixTransformToWorld(matrixTransformToWorld.GetPointer());
     }
 
   int ndnodes = model->GetNumberOfDisplayNodes();
@@ -2223,10 +2222,9 @@ vtkClipPolyData* vtkMRMLModelDisplayableManager::CreateTransformedClipper(
   vtkMRMLTransformNode* tnode = model->GetParentTransformNode();
   vtkNew<vtkMatrix4x4> transformToWorld;
   transformToWorld->Identity();
-  if (tnode != 0 && tnode->IsLinear())
+  if (tnode != 0 && tnode->IsTransformToWorldLinear())
     {
-    vtkMRMLLinearTransformNode *lnode = vtkMRMLLinearTransformNode::SafeDownCast(tnode);
-    lnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
+    tnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
 
     vtkNew<vtkImplicitBoolean> slicePlanes;
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.cxx
@@ -22,7 +22,6 @@
 #include <vtkMRMLColorNode.h>
 #include <vtkMRMLDisplayNode.h>
 #include <vtkMRMLDisplayableNode.h>
-#include <vtkMRMLLinearTransformNode.h>
 #include <vtkMRMLModelDisplayNode.h>
 #include <vtkMRMLModelNode.h>
 #include <vtkMRMLScene.h>

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest.cxx
@@ -15,7 +15,6 @@
 #include "vtkMRMLSliceLayerLogic.h"
 
 // MRML includes
-#include <vtkMRMLLinearTransformNode.h>
 #include <vtkMRMLModelDisplayNode.h>
 #include <vtkMRMLModelNode.h>
 #include <vtkMRMLScene.h>

--- a/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
@@ -20,9 +20,9 @@
 #include "vtkMRMLVectorVolumeDisplayNode.h"
 #include "vtkMRMLDiffusionWeightedVolumeDisplayNode.h"
 #include "vtkMRMLDiffusionTensorVolumeDisplayNode.h"
-#include "vtkMRMLLinearTransformNode.h"
 #include "vtkMRMLDiffusionTensorVolumeSliceDisplayNode.h"
 #include "vtkMRMLScene.h"
+#include "vtkMRMLTransformNode.h"
 
 // VTK includes
 #include <vtkAlgorithm.h>
@@ -1032,10 +1032,9 @@ void vtkMRMLSliceLayerLogic::UpdateGlyphs()
       vtkMRMLTransformNode* tnode = this->VolumeNode->GetParentTransformNode();
       vtkNew<vtkMatrix4x4> transformToWorld;
       //transformToWorld->Identity();unnecessary, transformToWorld is already identiy
-      if (tnode != 0 && tnode->IsLinear())
+      if (tnode != 0 && tnode->IsTransformToWorldLinear())
         {
-        vtkMRMLLinearTransformNode *lnode = vtkMRMLLinearTransformNode::SafeDownCast(tnode);
-        lnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
+        tnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
         transformToWorld->Invert();
         }
 

--- a/Libs/MRML/Widgets/qMRMLLinearTransformSlider.cxx
+++ b/Libs/MRML/Widgets/qMRMLLinearTransformSlider.cxx
@@ -25,7 +25,7 @@
 #include "qMRMLLinearTransformSlider.h"
 
 // MRML includes
-#include "vtkMRMLLinearTransformNode.h"
+#include "vtkMRMLTransformNode.h"
 
 // VTK includes
 #include <vtkNew.h>
@@ -39,7 +39,7 @@ public:
   qMRMLLinearTransformSliderPrivate();
   qMRMLLinearTransformSlider::TransformType            TypeOfTransform;
   qMRMLLinearTransformSlider::CoordinateReferenceType  CoordinateReference;
-  vtkWeakPointer<vtkMRMLLinearTransformNode>           MRMLTransformNode;
+  vtkWeakPointer<vtkMRMLTransformNode>                 MRMLTransformNode;
   double                                               OldPosition;
 };
 
@@ -120,7 +120,7 @@ qMRMLLinearTransformSlider::CoordinateReferenceType qMRMLLinearTransformSlider::
 }
 
 // --------------------------------------------------------------------------
-void qMRMLLinearTransformSlider::setMRMLTransformNode(vtkMRMLLinearTransformNode* transformNode)
+void qMRMLLinearTransformSlider::setMRMLTransformNode(vtkMRMLTransformNode* transformNode)
 {
   Q_D(qMRMLLinearTransformSlider);
 
@@ -134,11 +134,11 @@ void qMRMLLinearTransformSlider::setMRMLTransformNode(vtkMRMLLinearTransformNode
   this->onMRMLTransformNodeModified(transformNode);
   // If the node is NULL, any action on the widget is meaningless, this is why
   // the widget is disabled
-  this->setEnabled(transformNode != 0);
+  this->setEnabled(transformNode != 0 && transformNode->IsLinear());
 }
 
 // --------------------------------------------------------------------------
-vtkMRMLLinearTransformNode* qMRMLLinearTransformSlider::mrmlTransformNode()const
+vtkMRMLTransformNode* qMRMLLinearTransformSlider::mrmlTransformNode()const
 {
   Q_D(const qMRMLLinearTransformSlider);
   return d->MRMLTransformNode;
@@ -149,12 +149,19 @@ void qMRMLLinearTransformSlider::onMRMLTransformNodeModified(vtkObject* caller)
 {
   Q_D(qMRMLLinearTransformSlider);
 
-  vtkMRMLLinearTransformNode* transformNode = vtkMRMLLinearTransformNode::SafeDownCast(caller);
+  vtkMRMLTransformNode* transformNode = vtkMRMLTransformNode::SafeDownCast(caller);
   if (!transformNode)
     {
     return;
     }
   Q_ASSERT(d->MRMLTransformNode == transformNode);
+
+  bool isLinear = transformNode->IsLinear();
+  this->setEnabled(isLinear);
+  if (!isLinear)
+    {
+    return;
+    }
 
   vtkNew<vtkTransform> transform;
   if (d->MRMLTransformNode.GetPointer() != NULL)
@@ -206,7 +213,7 @@ void qMRMLLinearTransformSlider::applyTransformation(double _sliderPosition)
 {
   Q_D(qMRMLLinearTransformSlider);
 
-  if (d->MRMLTransformNode.GetPointer() == NULL)
+  if (d->MRMLTransformNode.GetPointer() == NULL || !d->MRMLTransformNode->IsLinear())
     {
     return;
     }

--- a/Libs/MRML/Widgets/qMRMLLinearTransformSlider.h
+++ b/Libs/MRML/Widgets/qMRMLLinearTransformSlider.h
@@ -27,7 +27,7 @@
 // MRML includes
 #include "qMRMLSliderWidget.h"
 
-class vtkMRMLLinearTransformNode;
+class vtkMRMLTransformNode;
 class vtkMatrix4x4;
 class qMRMLLinearTransformSliderPrivate;
 
@@ -72,13 +72,13 @@ public:
 
   ///
   /// Return the current transform node
-  vtkMRMLLinearTransformNode* mrmlTransformNode()const;
+  vtkMRMLTransformNode* mrmlTransformNode()const;
 
 public slots:
   ///
   /// Set the MRML node of interest
   /// Note that setting transformNode to 0 will disable the widget
-  void setMRMLTransformNode(vtkMRMLLinearTransformNode* transformNode);
+  void setMRMLTransformNode(vtkMRMLTransformNode* transformNode);
 
   ///
   /// Apply the appropriate rotation/translation according to the typeOfTransform of the slider.

--- a/Libs/MRML/Widgets/qMRMLMatrixWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLMatrixWidget.cxx
@@ -26,7 +26,7 @@
 #include "qMRMLMatrixWidget.h"
 
 // MRML includes
-#include <vtkMRMLLinearTransformNode.h>
+#include <vtkMRMLTransformNode.h>
 
 // VTK includes
 #include <vtkNew.h>
@@ -46,7 +46,7 @@ public:
     }
 
   qMRMLMatrixWidget::CoordinateReferenceType   CoordinateReference;
-  vtkWeakPointer<vtkMRMLLinearTransformNode>   MRMLTransformNode;
+  vtkWeakPointer<vtkMRMLTransformNode>         MRMLTransformNode;
   // Warning, this is not the real "transform, the real can be retrieved
   // by qVTKAbstractMatrixWidget->transform();
   vtkSmartPointer<vtkTransform>                Transform;
@@ -92,11 +92,11 @@ qMRMLMatrixWidget::CoordinateReferenceType qMRMLMatrixWidget::coordinateReferenc
 // --------------------------------------------------------------------------
 void qMRMLMatrixWidget::setMRMLTransformNode(vtkMRMLNode* node)
 {
-  this->setMRMLTransformNode(vtkMRMLLinearTransformNode::SafeDownCast(node));
+  this->setMRMLTransformNode(vtkMRMLTransformNode::SafeDownCast(node));
 }
 
 // --------------------------------------------------------------------------
-void qMRMLMatrixWidget::setMRMLTransformNode(vtkMRMLLinearTransformNode* transformNode)
+void qMRMLMatrixWidget::setMRMLTransformNode(vtkMRMLTransformNode* transformNode)
 {
   Q_D(qMRMLMatrixWidget);
 
@@ -111,11 +111,13 @@ void qMRMLMatrixWidget::setMRMLTransformNode(vtkMRMLLinearTransformNode* transfo
 
   d->MRMLTransformNode = transformNode;
 
+  this->setEnabled(transformNode->IsLinear());
+
   this->updateMatrix();
 }
 
 // --------------------------------------------------------------------------
-vtkMRMLLinearTransformNode* qMRMLMatrixWidget::mrmlTransformNode()const
+vtkMRMLTransformNode* qMRMLMatrixWidget::mrmlTransformNode()const
 {
   Q_D(const qMRMLMatrixWidget);
   return d->MRMLTransformNode;
@@ -130,6 +132,13 @@ void qMRMLMatrixWidget::updateMatrix()
     {
     this->setMatrixInternal(0);
     d->Transform = 0;
+    return;
+    }
+
+  bool isLinear = d->MRMLTransformNode->IsLinear();
+  this->setEnabled(isLinear);
+  if (!isLinear)
+    {
     return;
     }
 

--- a/Libs/MRML/Widgets/qMRMLMatrixWidget.h
+++ b/Libs/MRML/Widgets/qMRMLMatrixWidget.h
@@ -29,7 +29,7 @@
 #include "qMRMLWidgetsExport.h"
 
 class vtkMRMLNode;
-class vtkMRMLLinearTransformNode;
+class vtkMRMLTransformNode;
 class vtkMatrix4x4;
 class qMRMLMatrixWidgetPrivate;
 
@@ -54,12 +54,12 @@ public:
   void setCoordinateReference(CoordinateReferenceType coordinateReference);
   CoordinateReferenceType coordinateReference() const;
 
-  vtkMRMLLinearTransformNode* mrmlTransformNode()const;
+  vtkMRMLTransformNode* mrmlTransformNode()const;
 
 public slots:
   ///
   /// Set the MRML node of interest
-  void setMRMLTransformNode(vtkMRMLLinearTransformNode* transformNode);
+  void setMRMLTransformNode(vtkMRMLTransformNode* transformNode);
   void setMRMLTransformNode(vtkMRMLNode* node);
 
 protected slots:

--- a/Libs/MRML/Widgets/qMRMLSceneTransformModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLSceneTransformModel.cxx
@@ -101,7 +101,7 @@ bool qMRMLSceneTransformModel::reparent(vtkMRMLNode* node, vtkMRMLNode* newParen
     vtkMRMLTransformNode::SafeDownCast(newParent);
   if (transformableNode)
     {
-    if (transformNode && !transformNode->IsLinear() && !transformableNode->CanApplyNonLinearTransforms())
+    if (transformNode && !transformNode->IsTransformToWorldLinear() && !transformableNode->CanApplyNonLinearTransforms())
       {
       return false;
       }

--- a/Libs/MRML/Widgets/qMRMLTransformSliders.cxx
+++ b/Libs/MRML/Widgets/qMRMLTransformSliders.cxx
@@ -28,7 +28,7 @@
 #include <qMRMLUtils.h>
 
 // MRML includes
-#include "vtkMRMLLinearTransformNode.h"
+#include "vtkMRMLTransformNode.h"
 
 // VTK includes
 #include <vtkNew.h>
@@ -45,7 +45,7 @@ public:
     }
 
   qMRMLTransformSliders::TransformType   TypeOfTransform;
-  vtkMRMLLinearTransformNode*            MRMLTransformNode;
+  vtkMRMLTransformNode*                  MRMLTransformNode;
   QStack<qMRMLLinearTransformSlider*>    ActiveSliders;
 };
 
@@ -157,11 +157,11 @@ qMRMLTransformSliders::TransformType qMRMLTransformSliders::typeOfTransform() co
 // --------------------------------------------------------------------------
 void qMRMLTransformSliders::setMRMLTransformNode(vtkMRMLNode* node)
 {
-  this->setMRMLTransformNode(vtkMRMLLinearTransformNode::SafeDownCast(node));
+  this->setMRMLTransformNode(vtkMRMLTransformNode::SafeDownCast(node));
 }
 
 // --------------------------------------------------------------------------
-void qMRMLTransformSliders::setMRMLTransformNode(vtkMRMLLinearTransformNode* transformNode)
+void qMRMLTransformSliders::setMRMLTransformNode(vtkMRMLTransformNode* transformNode)
 {
   Q_D(qMRMLTransformSliders);
 
@@ -177,19 +177,25 @@ void qMRMLTransformSliders::setMRMLTransformNode(vtkMRMLLinearTransformNode* tra
 
   // If the node is NULL, any action on the widget is meaningless, this is why
   // the widget is disabled
-  this->setEnabled(transformNode != 0);
+  this->setEnabled(transformNode != 0 && transformNode->IsLinear());
   d->MRMLTransformNode = transformNode;
 }
 
 // --------------------------------------------------------------------------
 void qMRMLTransformSliders::onMRMLTransformNodeModified(vtkObject* caller)
 {
-  vtkMRMLLinearTransformNode* transformNode = vtkMRMLLinearTransformNode::SafeDownCast(caller);
+  vtkMRMLTransformNode* transformNode = vtkMRMLTransformNode::SafeDownCast(caller);
   if (!transformNode)
     {
     return;
     }
   Q_ASSERT(transformNode);
+  bool isLinear = transformNode->IsLinear();
+  this->setEnabled(isLinear);
+  if (!isLinear)
+    {
+    return;
+    }
 
   // If the type of transform is ROTATION, do not modify
   if(this->typeOfTransform() == qMRMLTransformSliders::ROTATION)
@@ -221,7 +227,7 @@ void qMRMLTransformSliders::onMRMLTransformNodeModified(vtkObject* caller)
 }
 
 // --------------------------------------------------------------------------
-CTK_GET_CPP(qMRMLTransformSliders, vtkMRMLLinearTransformNode*, mrmlTransformNode, MRMLTransformNode);
+CTK_GET_CPP(qMRMLTransformSliders, vtkMRMLTransformNode*, mrmlTransformNode, MRMLTransformNode);
 
 // --------------------------------------------------------------------------
 void qMRMLTransformSliders::setTitle(const QString& _title)

--- a/Libs/MRML/Widgets/qMRMLTransformSliders.h
+++ b/Libs/MRML/Widgets/qMRMLTransformSliders.h
@@ -31,7 +31,7 @@
 #include "qMRMLWidget.h"
 
 class vtkMRMLNode;
-class vtkMRMLLinearTransformNode;
+class vtkMRMLTransformNode;
 class vtkMatrix4x4;
 class qMRMLTransformSlidersPrivate;
 
@@ -119,7 +119,7 @@ public:
 
   ///
   /// Return the current MRML node of interest
-  vtkMRMLLinearTransformNode* mrmlTransformNode()const;
+  vtkMRMLTransformNode* mrmlTransformNode()const;
 
 signals:
   ///
@@ -136,7 +136,7 @@ signals:
 public slots:
   ///
   /// Set the MRML node of interest
-  void setMRMLTransformNode(vtkMRMLLinearTransformNode* transformNode);
+  void setMRMLTransformNode(vtkMRMLTransformNode* transformNode);
   void setMRMLTransformNode(vtkMRMLNode* node);
 
   ///

--- a/Libs/MRML/Widgets/qMRMLUtils.cxx
+++ b/Libs/MRML/Widgets/qMRMLUtils.cxx
@@ -26,8 +26,8 @@
 #include "qMRMLUtils.h"
 
 // MRML includes
-#include <vtkMRMLLinearTransformNode.h>
 #include <vtkMRMLScene.h>
+#include <vtkMRMLTransformNode.h>
 #include <vtkMRMLViewNode.h>
 
 // VTK includes
@@ -67,12 +67,12 @@ void qMRMLUtils::vtkMatrixToQVector(vtkMatrix4x4* matrix, QVector<double> & vect
 void qMRMLUtils::getTransformInCoordinateSystem(vtkMRMLNode* node, bool global,
     vtkTransform* transform)
 {
-  Self::getTransformInCoordinateSystem(vtkMRMLLinearTransformNode::SafeDownCast( node ),
+  Self::getTransformInCoordinateSystem(vtkMRMLTransformNode::SafeDownCast( node ),
     global, transform);
 }
 
 //------------------------------------------------------------------------------
-void qMRMLUtils::getTransformInCoordinateSystem(vtkMRMLLinearTransformNode* transformNode,
+void qMRMLUtils::getTransformInCoordinateSystem(vtkMRMLTransformNode* transformNode,
   bool global, vtkTransform* transform)
 {
   Q_ASSERT(transform);
@@ -83,7 +83,7 @@ void qMRMLUtils::getTransformInCoordinateSystem(vtkMRMLLinearTransformNode* tran
 
   transform->Identity();
 
-  if (!transformNode)
+  if (!transformNode || !transformNode->IsLinear())
     {
     return;
     }

--- a/Libs/MRML/Widgets/qMRMLUtils.h
+++ b/Libs/MRML/Widgets/qMRMLUtils.h
@@ -31,7 +31,7 @@
 
 class QStyle;
 class vtkMRMLNode;
-class vtkMRMLLinearTransformNode;
+class vtkMRMLTransformNode;
 class vtkTransform;
 class vtkMatrix4x4;
 class vtkMRMLScene;
@@ -54,7 +54,7 @@ public:
   ///
   Q_INVOKABLE static void getTransformInCoordinateSystem(vtkMRMLNode* transformNode, bool global,
     vtkTransform* transform);
-  Q_INVOKABLE static void getTransformInCoordinateSystem(vtkMRMLLinearTransformNode* transformNode,
+  Q_INVOKABLE static void getTransformInCoordinateSystem(vtkMRMLTransformNode* transformNode,
     bool global, vtkTransform* transform);
 
   /// Retrieve the number of visible view node associated with \a scene

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationROINode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationROINode.cxx
@@ -670,12 +670,11 @@ void vtkMRMLAnnotationROINode::GetTransformedPlanes(vtkPlanes *planes)
   points->Delete();
 
   vtkMRMLTransformNode* tnode = this->GetParentTransformNode();
-  if (tnode != NULL) // && tnode->IsLinear())
+  if (tnode != NULL) // && tnode->IsTransformToWorldLinear())
     {
     //vtkMatrix4x4* transformToWorld = vtkMatrix4x4::New();
     //transformToWorld->Identity();
-    //vtkMRMLLinearTransformNode *lnode = vtkMRMLLinearTransformNode::SafeDownCast(tnode);
-    //lnode->GetMatrixTransformToWorld(transformToWorld);
+    //tnode->GetMatrixTransformToWorld(transformToWorld);
 
     vtkGeneralTransform *transform = vtkGeneralTransform::New();
     tnode->GetTransformFromWorld(transform);

--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManager.cxx
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManager.cxx
@@ -24,7 +24,6 @@
 // MRML includes
 #include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLInteractionNode.h>
-#include <vtkMRMLLinearTransformNode.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLSelectionNode.h>
 #include <vtkMRMLSliceCompositeNode.h>
@@ -2048,12 +2047,11 @@ void vtkMRMLAnnotationDisplayableManager::GetWorldToLocalCoordinates(vtkMRMLAnno
     }
 
   vtkMRMLTransformNode* tnode = node->GetParentTransformNode();
-  if (tnode != NULL && tnode->IsLinear())
+  if (tnode != NULL && tnode->IsTransformToWorldLinear())
     {
     vtkNew<vtkMatrix4x4> transformToWorld;
     transformToWorld->Identity();
-    vtkMRMLLinearTransformNode *lnode = vtkMRMLLinearTransformNode::SafeDownCast(tnode);
-    lnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
+    tnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
     transformToWorld->Invert();
 
     double p[4];

--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationROIDisplayableManager.cxx
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationROIDisplayableManager.cxx
@@ -17,7 +17,6 @@
 
 // MRML includes
 #include <vtkMRMLInteractionNode.h>
-#include <vtkMRMLLinearTransformNode.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLSliceNode.h>
 #include <vtkMRMLTransformNode.h>
@@ -362,10 +361,9 @@ void vtkMRMLAnnotationROIDisplayableManager::PropagateMRMLToWidget(vtkMRMLAnnota
   transformToWorld->Identity();
 
   vtkMRMLTransformNode* tnode = roiNode->GetParentTransformNode();
-  if (tnode != NULL && tnode->IsLinear())
+  if (tnode != NULL && tnode->IsTransformToWorldLinear())
     {
-    vtkMRMLLinearTransformNode *lnode = vtkMRMLLinearTransformNode::SafeDownCast(tnode);
-    lnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
+    tnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
     }
   transformToWorld->Invert();
 
@@ -497,10 +495,9 @@ void vtkMRMLAnnotationROIDisplayableManager::PropagateMRMLToWidget2D(vtkMRMLAnno
   transformToWorld->Identity();
 
   vtkMRMLTransformNode* tnode = roiNode->GetParentTransformNode();
-  if (tnode != NULL && tnode->IsLinear())
+  if (tnode != NULL && tnode->IsTransformToWorldLinear())
     {
-    vtkMRMLLinearTransformNode *lnode = vtkMRMLLinearTransformNode::SafeDownCast(tnode);
-    lnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
+    tnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
     }
 
   // update the transform from world to screen space
@@ -755,10 +752,9 @@ void vtkMRMLAnnotationROIDisplayableManager::SetParentTransformToWidget(vtkMRMLA
 
   // get the nodes's transform node
   vtkMRMLTransformNode* tnode = node->GetParentTransformNode();
-  if (rep != NULL && tnode != NULL && tnode->IsLinear())
+  if (rep != NULL && tnode != NULL && tnode->IsTransformToWorldLinear())
     {
-    vtkMRMLLinearTransformNode *lnode = vtkMRMLLinearTransformNode::SafeDownCast(tnode);
-    lnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
+    tnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
     }
 
   vtkNew<vtkPropCollection> actors;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -20,10 +20,10 @@
 #include "vtkMRMLMarkupsDisplayNode.h"
 #include "vtkMRMLMarkupsNode.h"
 #include "vtkMRMLMarkupsStorageNode.h"
+#include "vtkMRMLTransformNode.h"
 
 // Slicer MRML includes
 #include "vtkMRMLScene.h"
-#include "vtkMRMLLinearTransformNode.h"
 
 // VTK includes
 #include <vtkAbstractTransform.h>
@@ -613,16 +613,15 @@ int vtkMRMLMarkupsNode::GetMarkupPointWorld(int markupIndex, int pointIndex, dou
   vtkMRMLTransformNode* tnode = this->GetParentTransformNode();
   vtkGeneralTransform *transformToWorld = vtkGeneralTransform::New();
   transformToWorld->Identity();
-  if (tnode != 0 && !tnode->IsLinear())
+  if (tnode != 0 && !tnode->IsTransformToWorldLinear())
     {
     tnode->GetTransformToWorld(transformToWorld);
     }
-  else if (tnode != NULL && tnode->IsLinear())
+  else if (tnode != NULL && tnode->IsTransformToWorldLinear())
     {
     vtkNew<vtkMatrix4x4> matrixTransformToWorld;
     matrixTransformToWorld->Identity();
-    vtkMRMLLinearTransformNode *lnode = vtkMRMLLinearTransformNode::SafeDownCast(tnode);
-    lnode->GetMatrixTransformToWorld(matrixTransformToWorld.GetPointer());
+    tnode->GetMatrixTransformToWorld(matrixTransformToWorld.GetPointer());
     transformToWorld->Concatenate(matrixTransformToWorld.GetPointer());
   }
 
@@ -829,16 +828,14 @@ void vtkMRMLMarkupsNode::SetMarkupPointWorld(const int markupIndex, const int po
   vtkMRMLTransformNode* tnode = this->GetParentTransformNode();
   vtkGeneralTransform *transformFromWorld = vtkGeneralTransform::New();
   transformFromWorld->Identity();
-  if (tnode != 0 && !tnode->IsLinear())
+  if (tnode != 0 && !tnode->IsTransformToWorldLinear())
     {
     tnode->GetTransformFromWorld(transformFromWorld);
     }
-  else if (tnode != NULL && tnode->IsLinear())
+  else if (tnode != NULL && tnode->IsTransformToWorldLinear())
     {
     vtkNew<vtkMatrix4x4> matrixTransformToWorld;
-    matrixTransformToWorld->Identity();
-    vtkMRMLLinearTransformNode *lnode = vtkMRMLLinearTransformNode::SafeDownCast(tnode);
-    lnode->GetMatrixTransformToWorld(matrixTransformToWorld.GetPointer());
+    tnode->GetMatrixTransformToWorld(matrixTransformToWorld.GetPointer());
     matrixTransformToWorld->Invert();
     transformFromWorld->Concatenate(matrixTransformToWorld.GetPointer());
   }

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager2D.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager2D.cxx
@@ -29,7 +29,6 @@
 // MRML includes
 #include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLInteractionNode.h>
-#include <vtkMRMLLinearTransformNode.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLSelectionNode.h>
 #include <vtkMRMLSliceCompositeNode.h>
@@ -1490,16 +1489,15 @@ void vtkMRMLMarkupsDisplayableManager2D::GetWorldToLocalCoordinates(vtkMRMLMarku
 
   vtkGeneralTransform *transformToWorld = vtkGeneralTransform::New();
   transformToWorld->Identity();
-  if (tnode != 0 && !tnode->IsLinear())
+  if (tnode != 0 && !tnode->IsTransformToWorldLinear())
     {
     tnode->GetTransformFromWorld(transformToWorld);
     }
-  else if (tnode != NULL && tnode->IsLinear())
+  else if (tnode != NULL && tnode->IsTransformToWorldLinear())
     {
     vtkNew<vtkMatrix4x4> matrixTransformToWorld;
     matrixTransformToWorld->Identity();
-    vtkMRMLLinearTransformNode *lnode = vtkMRMLLinearTransformNode::SafeDownCast(tnode);
-    lnode->GetMatrixTransformToWorld(matrixTransformToWorld.GetPointer());
+    tnode->GetMatrixTransformToWorld(matrixTransformToWorld.GetPointer());
     matrixTransformToWorld->Invert();
     transformToWorld->Concatenate(matrixTransformToWorld.GetPointer());
   }

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager3D.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager3D.cxx
@@ -29,7 +29,6 @@
 // MRML includes
 #include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLInteractionNode.h>
-#include <vtkMRMLLinearTransformNode.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLSelectionNode.h>
 #include <vtkMRMLSliceCompositeNode.h>
@@ -1142,16 +1141,15 @@ void vtkMRMLMarkupsDisplayableManager3D::GetWorldToLocalCoordinates(vtkMRMLMarku
   vtkMRMLTransformNode* tnode = node->GetParentTransformNode();
   vtkGeneralTransform *transformToWorld = vtkGeneralTransform::New();
   transformToWorld->Identity();
-  if (tnode != 0 && !tnode->IsLinear())
+  if (tnode != 0 && !tnode->IsTransformToWorldLinear())
     {
     tnode->GetTransformFromWorld(transformToWorld);
     }
-  else if (tnode != NULL && tnode->IsLinear())
+  else if (tnode != NULL && tnode->IsTransformToWorldLinear())
     {
     vtkNew<vtkMatrix4x4> matrixTransformToWorld;
     matrixTransformToWorld->Identity();
-    vtkMRMLLinearTransformNode *lnode = vtkMRMLLinearTransformNode::SafeDownCast(tnode);
-    lnode->GetMatrixTransformToWorld(matrixTransformToWorld.GetPointer());
+    tnode->GetMatrixTransformToWorld(matrixTransformToWorld.GetPointer());
     matrixTransformToWorld->Invert();
     transformToWorld->Concatenate(matrixTransformToWorld.GetPointer());
   }

--- a/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.cxx
+++ b/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.cxx
@@ -32,7 +32,6 @@
 // MRML includes
 #include "vtkMRMLApplicationLogic.h"
 #include "vtkMRMLCameraNode.h"
-#include "vtkMRMLLinearTransformNode.h"
 #include "vtkMRMLScene.h"
 #include "vtkMRMLSliceCompositeNode.h"
 #include "vtkMRMLSliceLogic.h"

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformsDisplayableManager2D.cxx
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformsDisplayableManager2D.cxx
@@ -28,7 +28,6 @@
 
 // MRML includes
 #include <vtkMRMLProceduralColorNode.h>
-#include <vtkMRMLLinearTransformNode.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLSliceCompositeNode.h>
 #include <vtkMRMLSliceNode.h>

--- a/Modules/Loadable/Transforms/Resources/UI/qSlicerTransformsModuleWidget.ui
+++ b/Modules/Loadable/Transforms/Resources/UI/qSlicerTransformsModuleWidget.ui
@@ -196,6 +196,19 @@
          </widget>
         </item>
         <item>
+         <widget class="QPushButton" name="SplitPushButton">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="toolTip">
+           <string>Split a composite transform to its components</string>
+          </property>
+          <property name="text">
+           <string>Split</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="horizontalSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>

--- a/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.cxx
+++ b/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.cxx
@@ -33,7 +33,6 @@
 #include <vtkMRMLNode.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLTransformNode.h>
-#include <vtkMRMLLinearTransformNode.h>
 
 // VTK includes
 #include <vtkObjectFactory.h>
@@ -233,7 +232,8 @@ void qSlicerSubjectHierarchyTransformsPlugin::showContextMenuActionsForNode(vtkM
   if (this->canOwnSubjectHierarchyNode(node))
     {
     d->InvertAction->setVisible(true);
-    if (node->GetAssociatedNode() && node->GetAssociatedNode()->IsA("vtkMRMLLinearTransformNode"))
+    vtkMRMLTransformNode* tnode = vtkMRMLTransformNode::SafeDownCast(node->GetAssociatedNode());
+    if (tnode && tnode->IsLinear())
       {
       d->IdentityAction->setVisible(true);
       }
@@ -273,10 +273,10 @@ void qSlicerSubjectHierarchyTransformsPlugin::invert()
 void qSlicerSubjectHierarchyTransformsPlugin::identity()
 {
   vtkMRMLSubjectHierarchyNode* currentNode = qSlicerSubjectHierarchyPluginHandler::instance()->currentNode();
-  vtkMRMLLinearTransformNode* linearTransformNode = vtkMRMLLinearTransformNode::SafeDownCast(currentNode->GetAssociatedNode());
-  if (linearTransformNode)
+  vtkMRMLTransformNode* transformNode = vtkMRMLTransformNode::SafeDownCast(currentNode->GetAssociatedNode());
+  if (transformNode && transformNode->IsLinear())
     {
     vtkNew<vtkMatrix4x4> matrix; // initialized to identity by default
-    linearTransformNode->SetMatrixTransformToParent(matrix.GetPointer());
+    transformNode->SetMatrixTransformToParent(matrix.GetPointer());
     }
 }

--- a/Modules/Loadable/Transforms/Testing/Cxx/qSlicerTransformsModuleWidgetTest.cxx
+++ b/Modules/Loadable/Transforms/Testing/Cxx/qSlicerTransformsModuleWidgetTest.cxx
@@ -28,7 +28,7 @@
 #include "qSlicerTransformsModule.h"
 #include "qSlicerTransformsModuleWidget.h"
 #include <vtkMRMLScene.h>
-#include <vtkMRMLLinearTransformNode.h>
+#include <vtkMRMLTransformNode.h>
 
 // VTK includes
 #include <vtkMatrix4x4.h>
@@ -49,7 +49,7 @@ private slots:
 void qSlicerTransformsModuleWidgetTester::testIdentity()
 {
   vtkNew<vtkMRMLScene> scene;
-  vtkNew<vtkMRMLLinearTransformNode> transformNode;
+  vtkNew<vtkMRMLTransformNode> transformNode;
   scene->AddNode(transformNode.GetPointer());
 
   qSlicerTransformsModule transformsModule;
@@ -75,7 +75,7 @@ void qSlicerTransformsModuleWidgetTester::testIdentity()
 void qSlicerTransformsModuleWidgetTester::testInvert()
 {
   vtkNew<vtkMRMLScene> scene;
-  vtkNew<vtkMRMLLinearTransformNode> transformNode;
+  vtkNew<vtkMRMLTransformNode> transformNode;
   scene->AddNode(transformNode.GetPointer());
 
   qSlicerTransformsModule transformsModule;

--- a/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.h
+++ b/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.h
@@ -54,6 +54,9 @@ public slots:
   /// Invert the transform.
   void invert();
 
+  /// Split composite transform to its components
+  void split();
+
 protected:
 
   virtual void setup();
@@ -63,6 +66,7 @@ protected slots:
   void onCoordinateReferenceButtonPressed(int id);
   void onNodeSelected(vtkMRMLNode* node);
   void onTranslationRangeChanged(double newMin, double newMax);
+  void onMRMLTransformNodeModified(vtkObject* caller);
 
   void transformSelectedNodes();
   void untransformSelectedNodes();


### PR DESCRIPTION
By hardening a non-linear transform on a vtkMRMLLinearTransformNode makes the contents of the linear transform node non-linear. This causes errors in many places in the code where linearity of the transform is tested by checking the class type instead of calling transform->IsLinear() or transform->IsTransformToParentLinear().

In the long term all specific transform nodes (linear, bspline, grid) should be removed and only the generic vtkMRMLTransformNode should be used everywhere. The specific classes are already “empty”, they do not contain any useful functionality, but they are be used in extensions (and still have not removed from everywhere in the Slicer core), so they have to be phased out gradually.

Specific problems:
• If affine transform is applied to bspline then bspline component is ignored
• If affine transform is applied to bspline and affine is hardened then the bspline component is lost.
• Hardening multiple nonlinear transforms on a transform sometimes results in incorrect composite transform

Fixes:
• Instead of casting to vtkMRMLLinearTransform IsLinear or IsTransformToWorldLinear has to be called to decide if a transform is linear (checking the class type does not work correctly for composite transforms)
• Fixed vtkMRMLTransformNode::ApplyTransform
• Moved full implementation of get/set transform matrix functions in vtkMRMLTransformNode (it further prepares removal of obsolete linear/bspline/grid transform node classes)

Enhancements:
• Allow splitting of composite transforms to its components (Transforms module: Split button – only displayed for composite transforms)
