### PR TITLE
ENH: Filter testing modules in module list depending on DeveloperMode

### DIFF
--- a/Base/QTGUI/Resources/UI/qSlicerSettingsDeveloperPanel.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSettingsDeveloperPanel.ui
@@ -26,6 +26,9 @@
      <property name="text">
       <string/>
      </property>
+     <property name="toolTip">
+      <string>Run the application in developer mode: testing modules are shown in the module list, Reload&amp;Test section is shown in scripted modules user interface, CLI module input and output files are not deleted after module execution</string>
+     </property>
     </widget>
    </item>
    <item row="1" column="0">

--- a/Base/QTGUI/qSlicerModulesMenu.cxx
+++ b/Base/QTGUI/qSlicerModulesMenu.cxx
@@ -20,6 +20,7 @@
 
 // Qt includes
 #include <QDebug>
+#include <QSettings>
 
 // CTK includes
 #include "qSlicerAbstractModule.h"
@@ -397,6 +398,29 @@ void qSlicerModulesMenu::addModule(qSlicerAbstractCoreModule* moduleToAdd)
     // ignore hidden modules
     return;
     }
+
+  // Only show modules in Testing category if developer mode is enabled
+  // to not clutter the module list for regular users with tests
+  QSettings settings;
+  bool developerModeEnabled = settings.value("Developer/DeveloperMode", false).toBool();
+  if (!developerModeEnabled)
+    {
+    bool testOnlyModule = true;
+    foreach(const QString& category, module->categories())
+      {
+      if (category.split('.').takeFirst()!="Testing")
+        {
+        testOnlyModule = false;
+        }
+      }
+    if (testOnlyModule)
+      {
+      // This module only appears in the Testing category but we are not in developer mode,
+      // so do not add this module to the module menu
+      return;
+      }
+    }
+
   QAction* moduleAction = module->action();
   Q_ASSERT(moduleAction);
   if (d->DuplicateActions)


### PR DESCRIPTION
In the module selector only show modules in Testing category if DeveloperMode is enabled in application settings
