### PR TITLE
BUG: Fixed slice intersection display of non-linearly transformed model nodes

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.cxx
@@ -22,7 +22,6 @@
 #include <vtkMRMLColorNode.h>
 #include <vtkMRMLDisplayNode.h>
 #include <vtkMRMLDisplayableNode.h>
-#include <vtkMRMLLinearTransformNode.h>
 #include <vtkMRMLModelDisplayNode.h>
 #include <vtkMRMLModelNode.h>
 #include <vtkMRMLScene.h>
@@ -70,9 +69,9 @@ public:
   struct Pipeline
     {
     vtkSmartPointer<vtkGeneralTransform> NodeToWorld;
-    vtkSmartPointer<vtkGeneralTransform> NodeFromWorld;
-    vtkSmartPointer<vtkGeneralTransform> TransformToSlice;
+    vtkSmartPointer<vtkTransform> TransformToSlice;
     vtkSmartPointer<vtkTransformPolyDataFilter> Transformer;
+    vtkSmartPointer<vtkTransformPolyDataFilter> ModelWarper;
     vtkSmartPointer<vtkPlane> Plane;
     vtkSmartPointer<vtkCutter> Cutter;
     vtkSmartPointer<vtkProp> Actor;
@@ -86,13 +85,11 @@ public:
 
   // Transforms
   void UpdateDisplayableTransforms(vtkMRMLDisplayableNode *node);
-  void GetNodeTransformToWorld(vtkMRMLTransformableNode* node,
-                              vtkGeneralTransform* transformToWorld,
-                              vtkGeneralTransform* transformFromWorld);
+  void GetNodeTransformToWorld(vtkMRMLTransformableNode* node, vtkGeneralTransform* transformToWorld);
   // Slice Node
   void SetSliceNode(vtkMRMLSliceNode* sliceNode);
   void UpdateSliceNode();
-  void SetSlicePlaneFromMatrix(vtkGeneralTransform* matrix, vtkPlane* plane);
+  void SetSlicePlaneFromMatrix(vtkMatrix4x4* matrix, vtkPlane* plane);
 
   // Display Nodes
   void AddDisplayNode(vtkMRMLDisplayableNode*, vtkMRMLDisplayNode*);
@@ -206,26 +203,17 @@ void vtkMRMLModelSliceDisplayableManager::vtkInternal
 
 //---------------------------------------------------------------------------
 void vtkMRMLModelSliceDisplayableManager::vtkInternal
-::SetSlicePlaneFromMatrix(vtkGeneralTransform *sliceMatrix, vtkPlane* plane)
+::SetSlicePlaneFromMatrix(vtkMatrix4x4* sliceMatrix, vtkPlane* plane)
 {
   double normal[3];
   double origin[3];
-  double *val;
-  val = sliceMatrix->TransformDoublePoint(0,0,0);
-  for (int i=0; i<3; i++)
+
+  // +/-1: orientation of the normal
+  const int planeOrientation = 1;
+  for (int i = 0; i < 3; i++)
     {
-    origin[i] = val[i];
-    }
-
-  normal[0]=0;
-  normal[1]=0;
-  normal[2]=1;
-
-  val = sliceMatrix->TransformDoubleNormalAtPoint(origin, normal);
-
-  for (int i=0; i<3; i++)
-    {
-    normal[i] = val[i];
+    normal[i] = planeOrientation * sliceMatrix->GetElement(i,2);
+    origin[i] = sliceMatrix->GetElement(i,3);
     }
 
   plane->SetNormal(normal);
@@ -234,11 +222,9 @@ void vtkMRMLModelSliceDisplayableManager::vtkInternal
 
 //---------------------------------------------------------------------------
 void vtkMRMLModelSliceDisplayableManager::vtkInternal
-::GetNodeTransformToWorld(vtkMRMLTransformableNode* node,
-                          vtkGeneralTransform* transformToWorld,
-                          vtkGeneralTransform* transformFromWorld)
+::GetNodeTransformToWorld(vtkMRMLTransformableNode* node, vtkGeneralTransform* transformToWorld)
 {
-  if (!node || !transformToWorld || !transformFromWorld)
+  if (!node || !transformToWorld)
     {
     return;
     }
@@ -247,10 +233,8 @@ void vtkMRMLModelSliceDisplayableManager::vtkInternal
     node->GetParentTransformNode();
 
   transformToWorld->Identity();
-  transformFromWorld->Identity();
   if (tnode)
     {
-    tnode->GetTransformFromWorld(transformFromWorld);
     tnode->GetTransformToWorld(transformToWorld);
     }
 }
@@ -268,9 +252,7 @@ void vtkMRMLModelSliceDisplayableManager::vtkInternal
     {
     if ( ((pipelinesIter = this->DisplayPipelines.find(*dnodesIter)) != this->DisplayPipelines.end()) )
       {
-      this->GetNodeTransformToWorld( mNode,
-                                    pipelinesIter->second->NodeToWorld,
-                                    pipelinesIter->second->NodeFromWorld);
+      this->GetNodeTransformToWorld( mNode, pipelinesIter->second->NodeToWorld);
       this->UpdateDisplayNodePipeline(pipelinesIter->first, pipelinesIter->second);
       }
     }
@@ -321,10 +303,10 @@ void vtkMRMLModelSliceDisplayableManager::vtkInternal
   Pipeline* pipeline = new Pipeline();
   pipeline->Actor = actor.GetPointer();
   pipeline->Cutter = vtkSmartPointer<vtkCutter>::New();
-  pipeline->TransformToSlice = vtkSmartPointer<vtkGeneralTransform>::New();
+  pipeline->TransformToSlice = vtkSmartPointer<vtkTransform>::New();
   pipeline->NodeToWorld = vtkSmartPointer<vtkGeneralTransform>::New();
-  pipeline->NodeFromWorld = vtkSmartPointer<vtkGeneralTransform>::New();
   pipeline->Transformer = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+  pipeline->ModelWarper = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
   pipeline->Plane = vtkSmartPointer<vtkPlane>::New();
 
   // Set up pipeline
@@ -332,6 +314,7 @@ void vtkMRMLModelSliceDisplayableManager::vtkInternal
   pipeline->Transformer->SetInputConnection(pipeline->Cutter->GetOutputPort());
   pipeline->Cutter->SetCutFunction(pipeline->Plane);
   pipeline->Cutter->SetGenerateCutScalars(0);
+  pipeline->Cutter->SetInputConnection(pipeline->ModelWarper->GetOutputPort());
   pipeline->Actor->SetVisibility(0);
 
   // Add actor to Renderer and local cache
@@ -391,33 +374,25 @@ void vtkMRMLModelSliceDisplayableManager::vtkInternal
       return;
       }
 #if (VTK_MAJOR_VERSION <= 5)
-    pipeline->Cutter->SetInput(polyData);
+    pipeline->ModelWarper->SetInput(polyData);
     // need this to update bounds of the locator, to avoid crash in the cutter
     polyData->Modified();
 #else
-    pipeline->Cutter->SetInputData(polyData);
+    pipeline->ModelWarper->SetInputData(polyData);
     // need this to update bounds of the locator, to avoid crash in the cutter
     modelDisplayNode->GetOutputPolyDataConnection()->GetProducer()->Update();
 #endif
 
-    //  Set Plane Transform
-    vtkNew<vtkGeneralTransform> xform;
-    xform->Identity();
-    xform->Concatenate(pipeline->NodeFromWorld);
-    xform->Concatenate(this->SliceXYToRAS);
+    pipeline->ModelWarper->SetTransform(pipeline->NodeToWorld);
 
-    this->SetSlicePlaneFromMatrix(xform.GetPointer(), pipeline->Plane);
+    //  Set Plane Transform
+    this->SetSlicePlaneFromMatrix(this->SliceXYToRAS, pipeline->Plane);
+    pipeline->Plane->Modified();
 
     //  Set PolyData Transform
-    vtkNew<vtkMatrix4x4> tempMat1;
-    tempMat1->DeepCopy(this->SliceXYToRAS);
-    tempMat1->Invert();
-
-    pipeline->TransformToSlice->Identity();
-    pipeline->TransformToSlice->Concatenate(tempMat1.GetPointer());
-    pipeline->TransformToSlice->Concatenate(pipeline->NodeToWorld);
-
-    pipeline->Plane->Modified();
+    vtkNew<vtkMatrix4x4> rasToSliceXY;
+    vtkMatrix4x4::Invert(this->SliceXYToRAS, rasToSliceXY.GetPointer());
+    pipeline->TransformToSlice->SetMatrix(rasToSliceXY.GetPointer());
 
     // optimization for slice to slice intersections which are 1 quad polydatas
     // no need for 50^3 default locator divisons


### PR DESCRIPTION
An additional polydata transform filter is added to the pipeline that applies the model-to-world transform to the model's polydata.
Fixes http://www.na-mic.org/Bug/view.php?id=3900
