### PR TITLE
ENH: Added logging functions for Python

### DIFF
--- a/Base/Python/CMakeLists.txt
+++ b/Base/Python/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 set(Slicer_PYTHON_SCRIPTS
+  slicer/log
   slicer/logic
   slicer/ScriptedLoadableModule
   slicer/slicerqt

--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -1,6 +1,7 @@
 import os, string
 import unittest
 from __main__ import qt, ctk, slicer
+import slicer.log
 
 class ScriptedLoadableModule:
   def __init__(self, parent):
@@ -115,8 +116,8 @@ class ScriptedLoadableModuleWidget:
     except Exception, e:
       import traceback
       traceback.print_exc()
-      qt.QMessageBox.warning(slicer.util.mainWindow(),
-          "Reload and Test", 'Exception!\n\n' + str(e) + "\n\nSee Python Console for Stack Trace")
+      errorMessage = "Reload and Test: Exception!\n\n" + str(e) + "\n\nSee Python Console for Stack Trace"
+      slicer.log.error(errorMessage, showMessageBox=True)
 
 class ScriptedLoadableModuleLogic():
 
@@ -175,17 +176,9 @@ class ScriptedLoadableModuleLogic():
     return node
 
   def delayDisplay(self,message,msec=1000):
-    #
-    # logic version of delay display
-    #
-    print(message)
-    self.info = qt.QDialog()
-    self.infoLayout = qt.QVBoxLayout()
-    self.info.setLayout(self.infoLayout)
-    self.label = qt.QLabel(message,self.info)
-    self.infoLayout.addWidget(self.label)
-    qt.QTimer.singleShot(msec, self.info.close)
-    self.info.exec_()
+    """Display a message in a popup window for a short time
+    """
+    slicer.log.info(message, True, msec)
 
   def clickAndDrag(self,widget,button='Left',start=(10,10),end=(10,40),steps=20,modifiers=[]):
     """Send synthetic mouse events to the specified widget (qMRMLSliceWidget or qMRMLThreeDView)
@@ -232,24 +225,24 @@ class ScriptedLoadableModuleTest(unittest.TestCase):
   """
 
   def delayDisplay(self,message,msec=1000):
-    """This utility method displays a small dialog and waits.
-    This does two things: 1) it lets the event loop catch up
-    to the state of the test so that rendering and widget updates
-    have all taken place before the test continues and 2) it
-    shows the user/developer/tester the state of the test
+    """Display messages to the user/tester during testing.
+    This method can be temporarily overridden to allow tests running
+    with longer or shorter message display time.
+    Displaying a dialog and waiting does two things:
+    1) it lets the event loop catch up to the state of the test so
+    that rendering and widget updates have all taken place before
+    the test continues and
+    2) it shows the user/developer/tester the state of the test
     so that we'll know when it breaks.
+    Note:
+    Information that might be useful (but not important enough to show
+    to the user) can be logged using slicer.log.info function.
+    Error messages should be displayed using slicer.log.error function.
     """
-    print(message)
-    self.info = qt.QDialog()
-    self.infoLayout = qt.QVBoxLayout()
-    self.info.setLayout(self.infoLayout)
-    self.label = qt.QLabel(message,self.info)
-    self.infoLayout.addWidget(self.label)
-    qt.QTimer.singleShot(msec, self.info.close)
-    self.info.exec_()
+    # By default simply use slicer.log.info with message popup enabled
+    slicer.log.info(message, True, msec)
 
   def runTest(self):
     """Run as few or as many tests as needed here.
     """
-    self.delayDisplay('No test is defined in '+self.__class__.__name__)
-
+    slicer.log.error('No test is defined in '+self.__class__.__name__)

--- a/Base/Python/slicer/log.py
+++ b/Base/Python/slicer/log.py
@@ -1,0 +1,41 @@
+""" This module contains functions for writing info or error messages to the application log."""
+
+import sys
+from __main__ import qt, slicer
+
+# Define an object (__m) to store all module global variables
+class ModuleGlobals:
+  pass
+__m = ModuleGlobals()
+__m.errorPopup = None
+
+def info(logMessage, showMessageBox=False, autoCloseMsec=1000):
+  """Write info message to the application log
+  If showMessageBox is True then this method displays a small dialog and
+  waits until the user clicks on OK button or after autoCloseMsec millisecond
+  elapses.
+  This does two things: 1) it lets the event loop catch up
+  to the state of the test so that rendering and widget updates
+  have all taken place before the test continues and 2) it
+  shows the user/developer/tester the state of the test
+  so that we'll know when it breaks.
+  """
+  print logMessage
+  if showMessageBox:
+    __m.errorPopup = qt.QDialog()
+    layout = qt.QVBoxLayout()
+    __m.errorPopup.setLayout(layout)
+    label = qt.QLabel(logMessage,__m.errorPopup)
+    layout.addWidget(label)
+    if autoCloseMsec>0:
+      qt.QTimer.singleShot(autoCloseMsec, __m.errorPopup.close)
+    __m.errorPopup.exec_()
+
+def error(logMessage, showMessageBox=False):
+  """Write error message to the application log
+  If showMessageBox is True then this method displays a small dialog box and waits
+  until the user clicks on OK button.
+  """
+  print >> sys.stderr, logMessage
+  if showMessageBox:
+    qt.QMessageBox.warning(slicer.util.mainWindow(), "Slicer module error", logMessage)

--- a/Extensions/Testing/ScriptedLoadableExtensionTemplate/ScriptedLoadableModuleTemplate/ScriptedLoadableModuleTemplate.py
+++ b/Extensions/Testing/ScriptedLoadableExtensionTemplate/ScriptedLoadableModuleTemplate/ScriptedLoadableModuleTemplate.py
@@ -2,6 +2,7 @@ import os
 import unittest
 from __main__ import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
+import slicer.log
 
 #
 # ScriptedLoadableModuleTemplate
@@ -20,6 +21,7 @@ class ScriptedLoadableModuleTemplate(ScriptedLoadableModule):
     self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware), Steve Pieper (Isomics)"] # replace with "Firstname Lastname (Org)"
     self.parent.helpText = """
     This is an example of scripted loadable module bundled in an extension.
+    It performs a simple thresholding on the input volume and optionally captures a screenshot.
     """
     self.parent.acknowledgementText = """
     This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc. and Steve Pieper, Isomics, Inc.  and was partially funded by NIH grant 3P41RR013218-12S1.
@@ -71,15 +73,26 @@ class ScriptedLoadableModuleTemplateWidget(ScriptedLoadableModuleWidget):
     self.outputSelector = slicer.qMRMLNodeComboBox()
     self.outputSelector.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
     self.outputSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", 0 )
-    self.outputSelector.selectNodeUponCreation = False
+    self.outputSelector.selectNodeUponCreation = True
     self.outputSelector.addEnabled = True
     self.outputSelector.removeEnabled = True
-    self.outputSelector.noneEnabled = False
+    self.outputSelector.noneEnabled = True
     self.outputSelector.showHidden = False
     self.outputSelector.showChildNodeTypes = False
     self.outputSelector.setMRMLScene( slicer.mrmlScene )
     self.outputSelector.setToolTip( "Pick the output to the algorithm." )
     parametersFormLayout.addRow("Output Volume: ", self.outputSelector)
+
+    #
+    # threshold value
+    #
+    self.imageThresholdSliderWidget = ctk.ctkSliderWidget()
+    self.imageThresholdSliderWidget.singleStep = 0.1
+    self.imageThresholdSliderWidget.minimum = -100
+    self.imageThresholdSliderWidget.maximum = 100
+    self.imageThresholdSliderWidget.value = 0.5
+    self.imageThresholdSliderWidget.setToolTip("Set threshold value for computing the output image. Voxels that have intensities lower than this value will set to zero.")
+    parametersFormLayout.addRow("Image threshold", self.imageThresholdSliderWidget)
 
     #
     # check box to trigger taking screen shots for later use in tutorials
@@ -88,17 +101,6 @@ class ScriptedLoadableModuleTemplateWidget(ScriptedLoadableModuleWidget):
     self.enableScreenshotsFlagCheckBox.checked = 0
     self.enableScreenshotsFlagCheckBox.setToolTip("If checked, take screen shots for tutorials. Use Save Data to write them to disk.")
     parametersFormLayout.addRow("Enable Screenshots", self.enableScreenshotsFlagCheckBox)
-
-    #
-    # scale factor for screen shots
-    #
-    self.screenshotScaleFactorSliderWidget = ctk.ctkSliderWidget()
-    self.screenshotScaleFactorSliderWidget.singleStep = 1.0
-    self.screenshotScaleFactorSliderWidget.minimum = 1.0
-    self.screenshotScaleFactorSliderWidget.maximum = 50.0
-    self.screenshotScaleFactorSliderWidget.value = 1.0
-    self.screenshotScaleFactorSliderWidget.setToolTip("Set scale factor for the screen shots.")
-    parametersFormLayout.addRow("Screenshot scale factor", self.screenshotScaleFactorSliderWidget)
 
     #
     # Apply Button
@@ -116,6 +118,9 @@ class ScriptedLoadableModuleTemplateWidget(ScriptedLoadableModuleWidget):
     # Add vertical spacer
     self.layout.addStretch(1)
 
+    # Refresh Apply button state
+    self.onSelect()
+
   def cleanup(self):
     pass
 
@@ -125,10 +130,8 @@ class ScriptedLoadableModuleTemplateWidget(ScriptedLoadableModuleWidget):
   def onApplyButton(self):
     logic = ScriptedLoadableModuleTemplateLogic()
     enableScreenshotsFlag = self.enableScreenshotsFlagCheckBox.checked
-    screenshotScaleFactor = int(self.screenshotScaleFactorSliderWidget.value)
-    print("Run the algorithm")
-    logic.run(self.inputSelector.currentNode(), self.outputSelector.currentNode(), enableScreenshotsFlag,screenshotScaleFactor)
-
+    imageThreshold = self.imageThresholdSliderWidget.value
+    logic.run(self.inputSelector.currentNode(), self.outputSelector.currentNode(), imageThreshold, enableScreenshotsFlag)
 
 #
 # ScriptedLoadableModuleTemplateLogic
@@ -145,24 +148,35 @@ class ScriptedLoadableModuleTemplateLogic(ScriptedLoadableModuleLogic):
   """
 
   def hasImageData(self,volumeNode):
-    """This is a dummy logic method that
+    """This is an example logic method that
     returns true if the passed in volume
     node has valid image data
     """
     if not volumeNode:
-      print('no volume node')
+      slicer.log.error('hasImageData failed: no volume node')
       return False
     if volumeNode.GetImageData() == None:
-      print('no image data')
+      slicer.log.error('hasImageData failed: no image data in volume node')
+      return False
+    return True
+
+  def isValidInputOutputData(self, inputVolumeNode, outputVolumeNode):
+    """Validates if the output is not the same as input
+    """
+    if not inputVolumeNode:
+      slicer.log.error('isValidInputOutputData failed: no input volume node defined')
+      return False
+    if not outputVolumeNode:
+      slicer.log.error('isValidInputOutputData failed: no output volume node defined')
+      return False
+    if inputVolumeNode.GetID()==outputVolumeNode.GetID():
+      slicer.log.error('isValidInputOutputData failed: input and output volume is the same. Create a new volume for output to avoid this error.')
       return False
     return True
 
   def takeScreenshot(self,name,description,type=-1):
     # show the message even if not taking a screen shot
-    self.delayDisplay(description)
-
-    if self.enableScreenshots == 0:
-      return
+    slicer.log.info('Take screenshot: '+description+'.\nResult is available in the Annotations module.', True, 3000)
 
     lm = slicer.app.layoutManager()
     # switch on the type to get the requested window
@@ -195,19 +209,28 @@ class ScriptedLoadableModuleTemplateLogic(ScriptedLoadableModuleLogic):
     slicer.qMRMLUtils().qImageToVtkImageData(qimage,imageData)
 
     annotationLogic = slicer.modules.annotations.logic()
-    annotationLogic.CreateSnapShot(name, description, type, self.screenshotScaleFactor, imageData)
+    annotationLogic.CreateSnapShot(name, description, type, 1, imageData)
 
-  def run(self,inputVolume,outputVolume,enableScreenshots=0,screenshotScaleFactor=1):
+  def run(self, inputVolume, outputVolume, imageThreshold, enableScreenshots=0):
     """
     Run the actual algorithm
     """
 
-    self.delayDisplay('Running the aglorithm')
+    if not self.isValidInputOutputData(inputVolume, outputVolume):
+      slicer.log.error('Input volume is the same as output volume. Choose a different output volume.', True)
+      return False
 
-    self.enableScreenshots = enableScreenshots
-    self.screenshotScaleFactor = screenshotScaleFactor
+    slicer.log.info('Processing started')
 
-    self.takeScreenshot('ScriptedLoadableModuleTemplate-Start','Start',-1)
+    # Compute the thresholded output volume using the Threshold Scalar Volume CLI module
+    cliParams = {'InputVolume': inputVolume.GetID(), 'OutputVolume': outputVolume.GetID(), 'ThresholdValue' : imageThreshold, 'ThresholdType' : 'Above'}
+    cliNode = slicer.cli.run(slicer.modules.thresholdscalarvolume, None, cliParams, wait_for_completion=True)
+
+    # Capture screenshot
+    if enableScreenshots:
+      self.takeScreenshot('ScriptedLoadableModuleTemplate-Start','MyScreenshot',-1)
+
+    slicer.log.info('Processing completed')
 
     return True
 
@@ -232,7 +255,7 @@ class ScriptedLoadableModuleTemplateTest(ScriptedLoadableModuleTest):
 
   def test_ScriptedLoadableModuleTemplate1(self):
     """ Ideally you should have several levels of tests.  At the lowest level
-    tests sould exercise the functionality of the logic with different inputs
+    tests should exercise the functionality of the logic with different inputs
     (both valid and invalid).  At higher levels your tests should emulate the
     way the user would interact with your code and confirm that it still works
     the way you intended.
@@ -254,12 +277,12 @@ class ScriptedLoadableModuleTemplateTest(ScriptedLoadableModuleTest):
     for url,name,loader in downloads:
       filePath = slicer.app.temporaryPath + '/' + name
       if not os.path.exists(filePath) or os.stat(filePath).st_size == 0:
-        print('Requesting download %s from %s...\n' % (name, url))
+        slicer.log.info('Requesting download %s from %s...\n' % (name, url))
         urllib.urlretrieve(url, filePath)
       if loader:
-        print('Loading %s...\n' % (name,))
+        slicer.log.info('Loading %s...' % (name,))
         loader(filePath)
-    self.delayDisplay('Finished with download and loading\n')
+    self.delayDisplay('Finished with download and loading')
 
     volumeNode = slicer.util.getNode(pattern="FA")
     logic = ScriptedLoadableModuleTemplateLogic()


### PR DESCRIPTION
Added info and error logging macros for Python modules. Usage examples

```
import slicer.log

slicer.log.info("This is an info message, logged as an INFO type message")
slicer.log.info("This is an info message, logged and also displayed in a popup for a short time", True)
slicer.log.info("This is an info message, logged and also displayed in a popup for 5 seconds", True, 5000)
slicer.log.info("This is an info message, logged and also displayed in a popup, the user has to click OK to continue", True, 0)

slicer.log.error("This is an error message, logged as an ERROR type message")
slicer.log.error("This is an error message, logged and also displayed in a popup, the user has to click OK to continue", True, 0)
```

Also updated the scripted loadable module template to perform actual image processing (thresholding, using a CLI) and not just capture a screenshot, because this is much closer to what most users would do.

Right now Python errors are logged as INFO messages due to a CTK bug. A pull request is submitted with a fix: https://github.com/commontk/CTK/pull/523
