### PR TITLE
BUG: avoid false positives on geometry check

### DIFF
--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.h
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.h
@@ -242,6 +242,20 @@ public:
   static vtkMRMLScalarVolumeNode* ResampleVolumeToReferenceVolume(vtkMRMLVolumeNode *inputVolumeNode,
                                                            vtkMRMLVolumeNode *referenceVolumeNode);
 
+  /// Getting the epsilon value to use when determining if the
+  /// elements of the IJK to RAS matrices of two volumes match.
+  /// Defaults to 10 to the minus 6.
+  vtkGetMacro(CompareVolumeGeometryEpsilon, double);
+  /// Setting the epsilon value and associated precision to use when determining
+  /// if the elements of the IJK to RAS matrices of two volumes match and how to
+  /// print out the mismatched elements.
+  void SetCompareVolumeGeometryEpsilon(double epsilon);
+
+  /// Get the precision with which to print out volume geometry mismatches,
+  /// value is set when setting the compare volume geometry epsilon.
+  /// \sa SetCompareVolumeGeometryEpsilon
+  vtkGetMacro(CompareVolumeGeometryPrecision, int);
+
 protected:
   vtkSlicerVolumesLogic();
   virtual ~vtkSlicerVolumesLogic();
@@ -273,6 +287,13 @@ protected:
   vtkSmartPointer<vtkMRMLColorLogic> ColorLogic;
 
   NodeSetFactoryRegistry VolumeRegistry;
+
+  /// Allowable difference in comparing volume geometry double values.
+  /// Defaults to 1 to the power of 10 to the minus 6
+  double CompareVolumeGeometryEpsilon;
+  /// Error print out precision, paried with CompareVolumeGeometryEpsilon.
+  /// defaults to 6
+  int CompareVolumeGeometryPrecision;
 };
 
 #endif

--- a/Modules/Loadable/Volumes/Testing/Python/CMakeLists.txt
+++ b/Modules/Loadable/Volumes/Testing/Python/CMakeLists.txt
@@ -2,3 +2,5 @@
 #  SLICER_ARGS --disable-cli-modules)
 
 slicer_add_python_unittest(SCRIPT LoadVolumeDisplaybleSceneModelClose.py)
+
+slicer_add_python_unittest(SLICER_ARGS --disable-cli-modules SCRIPT VolumesLogicCompareVolumeGeometry.py)

--- a/Modules/Loadable/Volumes/Testing/Python/VolumesLogicCompareVolumeGeometry.py
+++ b/Modules/Loadable/Volumes/Testing/Python/VolumesLogicCompareVolumeGeometry.py
@@ -1,0 +1,118 @@
+import unittest
+from  __main__ import vtk, qt, ctk, slicer
+
+
+class VolumesLogicCompareVolumeGeometryTesting(unittest.TestCase):
+  def setUp(self):
+    pass
+
+  def test_VolumesLogicCompareVolumeGeometry(self):
+    """
+    Load a volume, then call the compare volume geometry test with
+    different values of epsilon and precision.
+    """
+
+    #
+    # first, get some sample data
+    #
+    import SampleData
+    sampleDataLogic = SampleData.SampleDataLogic()
+    head = sampleDataLogic.downloadMRHead()
+
+    #
+    # get the volumes logic and print out default epsilon and precision
+    #
+    volumesLogic = slicer.modules.volumes.logic()
+    print 'Compare volume geometry epsilon: ', volumesLogic.GetCompareVolumeGeometryEpsilon()
+    print 'Compare volume geometry precision: ', volumesLogic.GetCompareVolumeGeometryPrecision()
+
+    #
+    # compare the head against itself, this shouldn't produce any warning
+    # string
+    #
+    warningString = volumesLogic.CompareVolumeGeometry(head, head)
+    if len(warningString) != 0:
+      print 'Error in checking MRHead geometry against itself'
+      print warningString
+      return False
+    else:
+      print 'Success in comparing MRHead vs itself with epsilon',volumesLogic.GetCompareVolumeGeometryEpsilon()
+
+    #
+    # see if you can get it to fail with a tighter epsilon
+    #
+    volumesLogic.SetCompareVolumeGeometryEpsilon(1e-10)
+    precision = volumesLogic.GetCompareVolumeGeometryPrecision()
+    if precision != 10:
+      print 'Error in calculating precision from epsilon of ', volumesLogic.GetCompareVolumeGeometryEpsilon(), ', expected 10, got ', precision
+      return False
+    warningString = volumesLogic.CompareVolumeGeometry(head, head)
+    if len(warningString) != 0:
+      print 'Error in checking MRHead geometry against itself with strict epsilon'
+      print warningString
+      return False
+    else:
+      print 'Success in comparing MRHead vs itself with epsilon',volumesLogic.GetCompareVolumeGeometryEpsilon()
+
+
+
+    #
+    # clone the volume so can test for mismatches in geometry with
+    # that operation
+    #
+    head2 = volumesLogic.CloneVolume(head, 'head2')
+
+    warningString  = volumesLogic.CompareVolumeGeometry(head, head2)
+    if len(warningString) != 0:
+      print 'Error in checking MRHead geometry against itself with epsilon ', volumesLogic.GetCompareVolumeGeometryEpsilon()
+      print warningString
+      return False
+    else:
+      print 'Success in comparing MRHead vs clone with epsilon',volumesLogic.GetCompareVolumeGeometryEpsilon()
+
+    #
+    # now try with a label map volume
+    #
+    headLabel = volumesLogic.CreateAndAddLabelVolume(head, "label vol")
+    warningString = volumesLogic.CompareVolumeGeometry(head, headLabel)
+    if len(warningString) != 0:
+      print 'Error in comparing MRHead geometry against a label map of itself with epsilon',volumesLogic.GetCompareVolumeGeometryEpsilon()
+      print warningString
+      return False
+    else:
+      print 'Success in comparing MRHead vs label map with epsilon',volumesLogic.GetCompareVolumeGeometryEpsilon()
+
+    #
+    # adjust the geometry and make it fail
+    #
+    head2Matrix = vtk.vtkMatrix4x4()
+    head2.GetRASToIJKMatrix(head2Matrix)
+    val = head2Matrix.GetElement(2,0)
+    head2Matrix.SetElement(2,0,val+0.25)
+    head2.SetRASToIJKMatrix(head2Matrix)
+    head2.SetSpacing(0.12345678901234567890, 2.0, 3.4)
+
+    warningString = volumesLogic.CompareVolumeGeometry(head,head2)
+    if len(warningString) == 0:
+      print 'Error in comparing MRHead geometry against an updated clone, with epsilon',volumesLogic.GetCompareVolumeGeometryEpsilon()
+      return False
+    else:
+      print 'Success in making the comparison fail, with with epsilon',volumesLogic.GetCompareVolumeGeometryEpsilon()
+      print warningString
+
+    #
+    # reset the epsilon with an invalid negative number
+    #
+    volumesLogic.SetCompareVolumeGeometryEpsilon(-0.01)
+    epsilon = volumesLogic.GetCompareVolumeGeometryEpsilon()
+    if epsilon != 0.01:
+      print 'Failed to use the absolute value for an epsilon of -0.01: ', epsilon
+      return False
+    precision = volumesLogic.GetCompareVolumeGeometryPrecision()
+    if precision != 2:
+      print 'Failed to set the precision to 2: ',precision
+      return False
+    warningString = volumesLogic.CompareVolumeGeometry(head,head2)
+    print warningString
+
+    return True


### PR DESCRIPTION
Add an epsilon value to the volumes logic and use it in the fuzzy compare instead
of the VTK default value. Add a precision calculation from the epsilon so that
any warning messages are printed out with the same precision as was used to
check the values.
Added a sanity check to see if the smallest volume spacing is within 3-10 orders
of magnitude of epsilon and print a warning if not.
Added a python test to exercise the epsilon, precision and geometry check.

TBD: GUI for setting epsilon or just always use a volume spacing based value.
