### PR TITLE
BUG: Fixed crash on scene close

### DIFF
--- a/Libs/MRML/Widgets/qMRMLSceneModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLSceneModel.cxx
@@ -419,13 +419,8 @@ vtkMRMLNode* qMRMLSceneModel::mrmlNodeFromItem(QStandardItem* nodeItem)const
     {
     return 0;
     }
-  //return nodeItem ? d->MRMLScene->GetNodeByID(
-  //  nodeItem->data(qMRMLSceneModel::UIDRole).toString().toLatin1()) : 0;
-  vtkMRMLNode* node = static_cast<vtkMRMLNode*>(
-    reinterpret_cast<void *>(
-      nodePointer.toLongLong()));
-  Q_ASSERT(node);
-  return node;
+  return nodeItem ? d->MRMLScene->GetNodeByID(
+    nodeItem->data(qMRMLSceneModel::UIDRole).toString().toLatin1()) : 0;
 }
 //------------------------------------------------------------------------------
 QStandardItem* qMRMLSceneModel::itemFromNode(vtkMRMLNode* node, int column)const


### PR DESCRIPTION
Node pointers in the scene model can become invalid when the scene is closed.
If the node is looked up by node ID and pointer is retrieved from the scene then the retrieved pointer will always be valid.
The d->MRMLScene->GetNodeByID() lookup takes some extra time, but it is not very slow, because it just finds a string in a std::map<string,...>.
