### PR TITLE
ENH: Add Set/Get and XML macros for iterable STL container properties

### DIFF
--- a/Libs/vtkAddon/CMakeLists.txt
+++ b/Libs/vtkAddon/CMakeLists.txt
@@ -63,6 +63,7 @@ set(vtkAddon_SRCS
   vtkPersonInformation.h
   vtkAddonMathUtilities.h
   vtkAddonMathUtilities.cxx
+  vtkAddonSetGet.h
   )
 
 # Abstract/pure virtual classes
@@ -76,6 +77,7 @@ set(vtkAddon_SRCS
 set_source_files_properties(
   vtkAddonTestingUtilities.h
   vtkLoggingMacros.h 
+  vtkAddonSetGet.h
   WRAP_EXCLUDE
   )
 # --------------------------------------------------------------------------

--- a/Libs/vtkAddon/vtkAddonSetGet.h
+++ b/Libs/vtkAddon/vtkAddonSetGet.h
@@ -1,0 +1,52 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+/// vtkAddonSetGet
+///
+/// vtkAddonSetGet adds additional Set/Get macros for currently unsupported types
+/// Types:
+///  stl containers,
+///
+
+#ifndef vtkAddonSetGet_h
+#define vtkAddonSetGet_h
+
+//
+// Set macro for STL containers. Sets the local variable to be a copy of the specified container.
+// Currently, STL containers cannot use the generic vtkSetMacro/vtkGetMacro types since those macros require a "<<" operator within vtkDebugMacro
+//
+#define vtkSetStdVectorMacro(name,type) \
+virtual void Set##name (type _arg) \
+{ \
+  if (this->name != _arg) \
+  { \
+    this->name = _arg; \
+    this->Modified(); \
+  } \
+}
+
+//
+// Get macro for STL containers. Returns a copy of the container.
+// Currently, STL containers cannot use the generic vtkSetMacro/vtkGetMacro types since those macros require a "<<" operator within vtkDebugMacro
+//
+#define vtkGetStdVectorMacro(name,type) \
+virtual type Get##name () { \
+  return this->name; \
+}
+
+#endif
+// VTK-HeaderTest-Exclude: vtkSetGet.h


### PR DESCRIPTION
Adds macros to Read/Write/Print/Copy iterable properties.

Example usage:

- Numeric container:
`vtkMRMLWriteXMLStdVectorMacro(property, Property, std::deque<int>);`

- String container:
`vtkMRMLWriteXMLStdStringVectorMacro(property, Property, std::vector);`

See also this related merge request in VTK: https://gitlab.kitware.com/vtk/vtk/merge_requests/4427
It's not required for this change, but it adds some convenience macros for setting/getting STL containers.

Also added generic Set/Get macros that work with STL containers.
Currently, STL containers cannot use the generic vtkSetMacro/vtkGetMacro types since those macros require a "<<" operator within vtkDebugMacro

https://github.com/openigtlink/SlicerOpenIGTLink/pull/36

cc: @lassoan 