### PR TITLE
ENH: Add pauseRender() and resumeRender() functions to qMRMLLayoutManager

### DIFF
--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -993,3 +993,28 @@ void qSlicerApplication::logApplicationInformation() const
          additionalModulePaths.isEmpty() ? "(none)" : qPrintable(additionalModulePaths.join(", ")));
 
 }
+
+//-----------------------------------------------------------------------------
+void qSlicerApplication::setRenderPaused(bool pause)
+{
+  Q_D(qSlicerApplication);
+
+  if (d->LayoutManager)
+    {
+    d->LayoutManager->setRenderPaused(pause);
+    }
+
+  emit renderPaused(pause);
+}
+
+//------------------------------------------------------------------------------
+void qSlicerApplication::pauseRender()
+{
+  this->setRenderPaused(true);
+}
+
+//------------------------------------------------------------------------------
+void qSlicerApplication::resumeRender()
+{
+  this->setRenderPaused(false);
+}

--- a/Base/QTGUI/qSlicerApplication.h
+++ b/Base/QTGUI/qSlicerApplication.h
@@ -171,6 +171,21 @@ public slots:
   /// See http://doc.qt.io/qt-5/windows-issues.html#fullscreen-opengl-based-windows
   void setHasBorderInFullScreen(bool);
 
+  /// Calls setRenderPaused(pause) on the current layout manager.
+  /// Emits pauseRenderRequested() if pause is true and resumeRenderRequested() if pause is false.
+  /// The caller is responsible for making sure that each setRenderPaused(true) is paired with
+  /// setRenderPaused(false).
+  /// \sa qMRMLLayoutManager::setRenderPaused()
+  void setRenderPaused(bool pause);
+
+  /// Equivalent to setRenderPaused(true)
+  /// \sa setRenderPaused
+  void pauseRender();
+
+  /// Equivalent to setRenderPaused(false)
+  /// \sa setRenderPaused
+  void resumeRender();
+
 signals:
 
   /// Emitted when the startup phase has been completed.
@@ -183,6 +198,10 @@ signals:
   ///
   /// \sa qSlicerAppMainWindow::initialWindowShown()
   void startupCompleted();
+
+  /// Emitted when setRenderPaused() is called
+  /// \sa setRenderPaused
+  void renderPaused(bool);
 
 protected:
   /// Reimplemented from qSlicerCoreApplication

--- a/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
@@ -24,6 +24,7 @@
 
 // MRMLWidgets includes
 #include <qMRMLLayoutManager_p.h>
+#include <qMRMLSliceView.h>
 #include <qMRMLSliceWidget.h>
 #include <qMRMLSliceControllerWidget.h>
 #include <qMRMLChartView.h>
@@ -1329,4 +1330,37 @@ QWidget* qMRMLLayoutManager::viewWidget(vtkMRMLNode* viewNode) const
   Q_D(const qMRMLLayoutManager);
 
   return d->viewWidget(viewNode);
+}
+
+//------------------------------------------------------------------------------
+void qMRMLLayoutManager::setRenderPaused(bool pause)
+{
+  // Note: views that are instantiated between pauseRender() calls will not be affected
+  // by the specified pause state
+  Q_D(qMRMLLayoutManager);
+  qMRMLLayoutViewFactory* sliceViewFactory = this->mrmlViewFactory("vtkMRMLSliceNode");
+  foreach(const QString& viewName, sliceViewFactory->viewNodeNames())
+    {
+    ctkVTKAbstractView* view = this->sliceWidget(viewName)->sliceView();
+    view->setRenderPaused(pause);
+    }
+
+  qMRMLLayoutViewFactory* threeDViewFactory = this->mrmlViewFactory("vtkMRMLViewNode");
+  foreach(const QString& viewName, threeDViewFactory->viewNodeNames())
+    {
+    ctkVTKAbstractView* view = this->threeDWidget(viewName)->threeDView();
+    view->setRenderPaused(pause);
+    }
+}
+
+//------------------------------------------------------------------------------
+void qMRMLLayoutManager::pauseRender()
+{
+  this->setRenderPaused(true);
+}
+
+//------------------------------------------------------------------------------
+void qMRMLLayoutManager::resumeRender()
+{
+  this->setRenderPaused(true);
 }

--- a/Libs/MRML/Widgets/qMRMLLayoutManager.h
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager.h
@@ -243,6 +243,20 @@ public slots:
   /// \sa qMRMLSliceControllerWidget::fitSliceToBackground(), vtkMRMLSliceLogic::FitSliceToAll()
   void resetSliceViews();
 
+  /// Calls setPauseRender(pause) on all slice and 3D views
+  /// Tracks the previous pause state which is restored using resumeRender()
+  /// Each pauseRender(true) should always be accompanied by a corresponding pauseRender(false) call
+  /// \sa pauseRender
+  void setRenderPaused(bool pause);
+
+  /// Equivalent to setRenderPaused(true)
+  /// \sa setRenderPaused
+  void pauseRender();
+
+  /// Equivalent to setRenderPaused(false)
+  /// \sa setRenderPaused
+  void resumeRender();
+
 signals:
   void activeMRMLThreeDViewNodeChanged(vtkMRMLViewNode* newActiveMRMLThreeDViewNode);
   void activeMRMLChartViewNodeChanged(vtkMRMLChartViewNode* newActiveMRMLChartViewNode);


### PR DESCRIPTION
When modifying or setting up nodes that may trigger a render event, pauseRender can be called to temporarily stop the views from rendering intermediate steps.
Once all modifications have been completed, calling resumeRender will restore the previously stored pause states.

Depends on https://github.com/commontk/CTK/pull/827

-----

Edited by @jcfr: 

To understand the motivation see https://github.com/commontk/CTK/pull/827#issue-213722434 and exchange between @finetjul  and @lassoan  copied from https://github.com/commontk/CTK/pull/827#issuecomment-419428173 

> > From @finetjul :
> > Please explain how different it is from renderEnabled.

> From @lassoan 
> Good point. There is a very important difference (rendering requests arriving while renderEnabled(false) makes rendering requests to be forgotten, while they are just delayed while rendering is paused) but it may not be obvious at first.
> 
> Another important advantage of pauseRender is that it can be called from high-level application code, where it is not clear if a certain change will eventually require re-rendering or not. When pauseRender is turned off, rendering will only be performed if it was requested while rendering was paused (in contrast, after renderEnabled(false) you must always re-render).
> 
> I think renderEnabled is mostly made obsolete by the new mechanism.
> 

Cc: @ihnorton 
