### PR TITLE
ENH: Add generic storage node for Markups

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -376,6 +376,11 @@ def loadMarkupsFiducialList(filename, returnNode=False):
   properties = {}
   return loadNodeFromFile(filename, filetype, properties, returnNode)
 
+def loadMarkups(filename, returnNode=False):
+  filetype = 'Markups'
+  properties = {}
+  return loadNodeFromFile(filename, filetype, properties, returnNode)
+
 def loadModel(filename, returnNode=False):
   filetype = 'ModelFile'
   return loadNodeFromFile(filename, filetype, {}, returnNode)

--- a/Modules/Loadable/Markups/CMakeLists.txt
+++ b/Modules/Loadable/Markups/CMakeLists.txt
@@ -36,6 +36,8 @@ set(MODULE_SRCS
   qSlicer${MODULE_NAME}ModuleWidget.h
   qSlicer${MODULE_NAME}Reader.cxx
   qSlicer${MODULE_NAME}Reader.h
+  qSlicer${MODULE_NAME}FiducialsReader.cxx
+  qSlicer${MODULE_NAME}FiducialsReader.h
   qSlicer${MODULE_NAME}SettingsPanel.cxx
   qSlicer${MODULE_NAME}SettingsPanel.h
   )
@@ -44,6 +46,7 @@ set(MODULE_MOC_SRCS
   qSlicer${MODULE_NAME}Module.h
   qSlicer${MODULE_NAME}ModuleWidget.h
   qSlicer${MODULE_NAME}Reader.h
+  qSlicer${MODULE_NAME}FiducialsReader.h
   qSlicer${MODULE_NAME}SettingsPanel.h
   )
 

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
@@ -108,6 +108,11 @@ public:
   /// as well.
   char *LoadMarkupsFiducials(const char *fileName, const char *fidsName);
 
+  /// Load a markups from fileName, return NULL on error, node ID string
+  /// otherwise. Adds the appropriate storage and display nodes to the scene
+  /// as well.
+  char *LoadMarkups(const char *fileName, const char *name);
+
   /// Utility methods to operate on all markups in a markups node
   void SetAllMarkupsVisibility(vtkMRMLMarkupsNode *node, bool flag);
   void ToggleAllMarkupsVisibility(vtkMRMLMarkupsNode *node);

--- a/Modules/Loadable/Markups/MRML/CMakeLists.txt
+++ b/Modules/Loadable/Markups/MRML/CMakeLists.txt
@@ -30,3 +30,12 @@ SlicerMacroBuildModuleMRML(
   SRCS ${${KIT}_SRCS}
   TARGET_LIBRARIES ${${KIT}_TARGET_LIBRARIES}
   )
+
+#-----------------------------------------------------------------------------
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../Resources/GenericStorage.markups.json
+  ${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_SHARE_DIR}/${MODULE_NAME}/GenericStorage.markups.json
+  COPYONLY)
+install(
+  FILES ${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_SHARE_DIR}/${MODULE_NAME}/GenericStorage.markups.json
+  DESTINATION ${Slicer_INSTALL_QTLOADABLEMODULES_SHARE_DIR}/${MODULE_NAME} COMPONENT Runtime)

--- a/Modules/Loadable/Markups/MRML/CMakeLists.txt
+++ b/Modules/Loadable/Markups/MRML/CMakeLists.txt
@@ -2,9 +2,12 @@ project(vtkSlicer${MODULE_NAME}ModuleMRML)
 
 set(KIT ${PROJECT_NAME})
 
+find_package(RapidJSON REQUIRED)
+
 set(${KIT}_EXPORT_DIRECTIVE "VTK_SLICER_${MODULE_NAME_UPPER}_MODULE_MRML_EXPORT")
 
 set(${KIT}_INCLUDE_DIRECTORIES
+  ${RapidJSON_INCLUDE_DIR}
   )
 
 set(${KIT}_SRCS
@@ -12,6 +15,7 @@ set(${KIT}_SRCS
   vtkMRML${MODULE_NAME}FiducialNode.cxx
   vtkMRML${MODULE_NAME}Node.cxx
   vtkMRML${MODULE_NAME}FiducialStorageNode.cxx
+  vtkMRML${MODULE_NAME}GenericStorageNode.cxx
   )
 
 set(${KIT}_TARGET_LIBRARIES

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsGenericStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsGenericStorageNode.cxx
@@ -1,0 +1,558 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Johan Andruejol, Kitware Inc.
+  and was partially funded by Allen Institute.
+
+==============================================================================*/
+
+#include "vtkMRMLMarkupsDisplayNode.h"
+#include "vtkMRMLMarkupsGenericStorageNode.h"
+#include "vtkMRMLMarkupsNode.h"
+
+#include "vtkMRMLScene.h"
+#include "vtkSlicerVersionConfigure.h"
+
+#include "vtkObjectFactory.h"
+#include "vtkStringArray.h"
+#include <vtksys/SystemTools.hxx>
+#include "vtkVariantArray.h"
+#include "vtkDoubleArray.h"
+
+// JSON includes
+#include "rapidjson/document.h"
+#include "rapidjson/filereadstream.h"
+#include "rapidjson/filewritestream.h"
+#include "rapidjson/pointer.h"
+#include "rapidjson/prettywriter.h"
+
+//------------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLMarkupsGenericStorageNode);
+
+//---------------------------------------------------------------------------
+class vtkMRMLMarkupsGenericStorageNode::vtkInternal
+{
+public:
+  vtkInternal(vtkMRMLMarkupsGenericStorageNode* external);
+  ~vtkInternal();
+
+public:
+  void TranslationMapToJSON(
+    vtkMRMLMarkupsGenericStorageNode::TranslationMap& map,
+    rapidjson::Document* doc);
+
+  void JSONObjectToTranslationMap(
+    const rapidjson::Value& object,
+    vtkMRMLMarkupsGenericStorageNode::TranslationMap& map,
+    std::string baseKey = "");
+
+  void JSONArrayToTranslationMap(
+    const rapidjson::Value& object,
+    vtkMRMLMarkupsGenericStorageNode::TranslationMap& map,
+    std::string baseKey = "");
+
+  void JSONNodeToTranslationMap(
+    const rapidjson::Value& object,
+    vtkMRMLMarkupsGenericStorageNode::TranslationMap& map,
+    std::string baseKey = "");
+};
+
+//---------------------------------------------------------------------------
+// vtkInternal methods
+//---------------------------------------------------------------------------
+vtkMRMLMarkupsGenericStorageNode::vtkInternal
+::vtkInternal(vtkMRMLMarkupsGenericStorageNode * vtkNotUsed(external))
+{
+}
+
+#define WriteValue(VTKType, Type)                                            \
+  case VTKType:                                                              \
+    {                                                                        \
+    rapidjson::Pointer(key.c_str()).Set(*doc, value.To##Type());             \
+    break;                                                                   \
+    }
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsGenericStorageNode::vtkInternal::TranslationMapToJSON(
+  vtkMRMLMarkupsGenericStorageNode::TranslationMap& map, rapidjson::Document* doc)
+{
+  typedef vtkMRMLMarkupsGenericStorageNode::TranslationMap::const_iterator IteratorType;
+  for (IteratorType it = map.begin(); it != map.end(); ++it)
+    {
+    std::string key = it->first;
+    vtkVariant value = it->second;
+    if (value.IsValid())
+      {
+      switch (value.GetType())
+        {
+        WriteValue(VTK_FLOAT, Float)
+        WriteValue(VTK_DOUBLE, Double)
+        WriteValue(VTK_CHAR, Char)
+        WriteValue(VTK_UNSIGNED_CHAR, UnsignedChar)
+        WriteValue(VTK_SIGNED_CHAR, SignedChar)
+        WriteValue(VTK_SHORT, Short)
+        WriteValue(VTK_UNSIGNED_SHORT, UnsignedShort)
+        WriteValue(VTK_INT, Int)
+        WriteValue(VTK_UNSIGNED_INT, UnsignedInt)
+        default:
+          {
+          rapidjson::Pointer(key.c_str()).Set(*doc, value.ToString().c_str());
+          }
+        }
+      }
+    else
+      {
+      rapidjson::Pointer(key.c_str()).Create(*doc);
+      }
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsGenericStorageNode::vtkInternal::JSONObjectToTranslationMap(
+  const rapidjson::Value& node,
+  vtkMRMLMarkupsGenericStorageNode::TranslationMap& map,
+  std::string baseKey)
+{
+  for (rapidjson::Value::ConstMemberIterator childNode = node.MemberBegin();
+    childNode != node.MemberEnd(); ++childNode)
+    {
+    std::stringstream key;
+    key << baseKey << "/" << childNode->name.GetString();
+    this->JSONNodeToTranslationMap(childNode->value, map, key.str());
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsGenericStorageNode::vtkInternal::JSONArrayToTranslationMap(
+  const rapidjson::Value& node,
+  vtkMRMLMarkupsGenericStorageNode::TranslationMap& map,
+  std::string baseKey)
+{
+  for (rapidjson::SizeType i = 0; i < node.Size(); ++i)
+    {
+    std::stringstream key;
+    key << baseKey << "/" << i ;
+    this->JSONNodeToTranslationMap(node[i], map, key.str());
+    }
+}
+
+#define ReadValue(Type)                                                      \
+  else if (node.Is##Type())                                                  \
+    {                                                                        \
+    map[baseKey] = node.Get##Type();                                         \
+    }
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsGenericStorageNode::vtkInternal::JSONNodeToTranslationMap(
+  const rapidjson::Value& node,
+  vtkMRMLMarkupsGenericStorageNode::TranslationMap& map,
+  std::string baseKey)
+{
+  if (node.IsArray())
+    {
+    this->JSONArrayToTranslationMap(node, map, baseKey);
+    }
+  else if (node.IsObject())
+    {
+    this->JSONObjectToTranslationMap(node, map, baseKey);
+    }
+  else
+    {
+    if (node.IsNull())
+      {
+      map[baseKey] = vtkVariant();
+      }
+    ReadValue(String)
+    ReadValue(Double)
+    ReadValue(Float)
+    ReadValue(Int)
+    ReadValue(Uint)
+    ReadValue(Int64)
+    ReadValue(Uint64)
+    ReadValue(Bool)
+    }
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLMarkupsGenericStorageNode::vtkMRMLMarkupsGenericStorageNode()
+{
+  this->DefaultWriteFileExtension = "markups.json";
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLMarkupsGenericStorageNode::~vtkMRMLMarkupsGenericStorageNode()
+{
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLMarkupsGenericStorageNode::CanReadInReferenceNode(vtkMRMLNode *refNode)
+{
+  return refNode->IsA("vtkMRMLMarkupsNode");
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLMarkupsGenericStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
+{
+  if (!refNode)
+    {
+    vtkErrorMacro("ReadDataInternal: null reference node!");
+    return 0;
+    }
+
+  std::string fullName = this->GetFullNameFromFileName();
+
+  if (fullName.empty())
+    {
+    vtkErrorMacro("vtkMRMLMarkupsGenericStorageNode: File name not specified");
+    return 0;
+    }
+
+  // cast the input node
+  vtkMRMLMarkupsNode *markupsNode =
+    vtkMRMLMarkupsNode::SafeDownCast(refNode);
+  if (!markupsNode)
+    {
+    return 0;
+    }
+
+  // get the display node
+  vtkMRMLMarkupsDisplayNode *displayNode = NULL;
+  vtkMRMLDisplayNode * mrmlNode = markupsNode->GetDisplayNode();
+  if (mrmlNode)
+    {
+    displayNode = vtkMRMLMarkupsDisplayNode::SafeDownCast(mrmlNode);
+    }
+  if (!displayNode)
+    {
+    vtkWarningMacro("vtkMRMLMarkupsGenericStorageNode: no display node!");
+    if (this->GetScene())
+      {
+      vtkWarningMacro("vtkMRMLMarkupsGenericStorageNode: adding a new display node.");
+      displayNode = vtkMRMLMarkupsDisplayNode::New();
+      this->GetScene()->AddNode(displayNode);
+      markupsNode->SetAndObserveDisplayNodeID(displayNode->GetID());
+      displayNode->Delete();
+      }
+    }
+
+  rapidjson::Document* markupsRoot = new rapidjson::Document;
+  FILE *file = fopen(fullName.c_str(), "r");
+  if (!file)
+    {
+    vtkErrorMacro(
+      "vtkMRMLMarkupsGenericStorageNode: Failed to load from file '" << fullName << "'");
+    return 0;
+    }
+
+  char buffer[4096];
+  rapidjson::FileReadStream readStream(file, buffer, sizeof(buffer));
+  if (markupsRoot->ParseStream(readStream).HasParseError())
+    {
+    vtkErrorMacro(
+      "vtkMRMLMarkupsGenericStorageNode: Failed to load from file '" << fullName << "'");
+    fclose(file);
+    return 0;
+    }
+  fclose(file);
+
+  TranslationMap markupsMap;
+  rapidjson::Value rootValue = markupsRoot->GetObject();
+  this->Internal->JSONNodeToTranslationMap(rootValue, markupsMap);
+  if (!this->ReadMarkupsNodeFromTranslationMap(markupsNode, markupsMap))
+    {
+    vtkErrorMacro("vtkMRMLMarkupsGenericStorageNode: Error while converting JSON to markup")
+      return 0;
+    }
+
+  return 1;
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLMarkupsGenericStorageNode::ReadMarkupsNodeFromTranslationMap(
+  vtkMRMLMarkupsNode* markupsNode, TranslationMap& markupsMap)
+{
+  if (!markupsNode)
+    {
+    return 0;
+    }
+
+  int success = 1;
+
+  // Locked
+  markupsNode->SetLocked(markupsMap["/Locked"].ToInt());
+  // MarkupLabelFormat
+  markupsNode->SetMarkupLabelFormat(markupsMap["/MarkupLabelFormat"].ToString());
+  // TextList
+  size_t textList_size = markupsMap["/TextList_Count"].ToInt();
+  for (size_t i = 0; i < textList_size; ++i)
+    {
+    std::stringstream key;
+    key << "/TextList/" << i;
+    markupsNode->AddText(markupsMap[key.str()].ToString());
+    }
+  // Markups
+  size_t markups_Size = markupsMap["/Markups_Count"].ToInt();
+  for (size_t i = 0; i < markups_Size; ++i)
+    {
+    if (!markupsNode->MarkupExists(i))
+      {
+      Markup m;
+      markupsNode->InitMarkup(&m);
+      markupsNode->AddMarkup(m);
+      }
+
+    std::stringstream subKey;
+    subKey << "/Markups/" << i << "/";
+
+    success &=  this->ReadNthMarkupFromTranslationMap(
+        i, subKey.str(), markupsNode, markupsMap);
+    }
+  return success;
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLMarkupsGenericStorageNode::ReadNthMarkupFromTranslationMap(
+  int n, std::string key,
+  vtkMRMLMarkupsNode* markupsNode, TranslationMap& markupsMap)
+{
+  if (!markupsNode || !markupsNode->MarkupExists(n))
+    {
+    return 0;
+    }
+
+  Markup* markup = markupsNode->GetNthMarkup(n);
+
+  // ID
+  markup->ID = markupsMap[key + "ID"].ToString();
+  // Label
+  markup->Label = markupsMap[key + "Label"].ToString();
+  // Description
+  markup->Description = markupsMap[key + "Description"].ToString();
+  // AssociatedNodeID
+  markup->AssociatedNodeID = markupsMap[key + "AssociatedNodeID"].ToString();
+  // Points
+  size_t points_size = markupsMap[key + "Points_Count"].ToInt();
+  for (size_t i = 0; i < points_size; ++i)
+    {
+    std::stringstream pointsKey;
+    pointsKey << key << "Points/" << i;
+
+    markup->points.push_back(
+      vtkVector3d(
+        markupsMap[pointsKey.str() + "/x"].ToDouble(),
+        markupsMap[pointsKey.str() + "/y"].ToDouble(),
+        markupsMap[pointsKey.str() + "/z"].ToDouble())
+      );
+    }
+  // OrientationWXYZ
+  for (int i = 0; i < 4; ++i)
+    {
+    std::stringstream orientationKey;
+    orientationKey << key << "OrientationWXYZ/" << i;
+    markup->OrientationWXYZ[i] = markupsMap[orientationKey.str()].ToDouble();
+   }
+  // NOTE: vtkVariant stores bool as a char, which gives weird result in JSON.
+  // -> Force the bool to int.
+  // Selected
+  markup->Selected = markupsMap[key + "Selected"].ToInt();
+  // Selected
+  markup->Locked = markupsMap[key + "Locked"].ToInt() != 0;
+  // Selected
+  markup->Visibility = markupsMap[key + "Visibility"].ToInt();
+
+  return 1;
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLMarkupsGenericStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
+{
+  std::string fullName = this->GetFullNameFromFileName();
+  if (fullName.empty())
+    {
+    vtkErrorMacro("vtkMRMLMarkupsGenericStorageNode: File name not specified");
+    return 0;
+    }
+
+  // cast the input node
+  vtkMRMLMarkupsNode *markupsNode = vtkMRMLMarkupsNode::SafeDownCast(refNode);
+  if (!markupsNode)
+    {
+    vtkErrorMacro(
+      "vtkMRMLMarkupsGenericStorageNode: uUnable to cast input node "
+      << refNode->GetID() << " to a known markups node");
+    return 0;
+    }
+
+  TranslationMap markupMap;
+  if (!this->WriteMarkupsNodeToTranslationMap(markupsNode, markupMap))
+    {
+    vtkErrorMacro("vtkMRMLMarkupsGenericStorageNode: Error while converting markup to JSON")
+    return 0;
+    }
+
+  rapidjson::Document* markupsRoot = new rapidjson::Document;
+  this->Internal->TranslationMapToJSON(markupMap, markupsRoot);
+  FILE *file = fopen(fullName.c_str(), "w");
+  if (!file)
+    {
+    vtkErrorMacro(
+      "vtkMRMLMarkupsGenericStorageNode: Failed to write to file '" << fullName << "'");
+    return 0;
+    }
+
+  char writeBuffer[4096];
+  rapidjson::FileWriteStream writeStream(file, writeBuffer, sizeof(writeBuffer));
+  rapidjson::Writer<rapidjson::FileWriteStream> writer(writeStream);
+  if (!markupsRoot->Accept(writer))
+    {
+    vtkErrorMacro(
+      "vtkMRMLMarkupsGenericStorageNode: Error while writing to file '" << fullName << "'");
+    fclose(file);
+    return 0;
+    }
+
+  fclose(file);
+  return 1;
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLMarkupsGenericStorageNode::WriteMarkupsNodeToTranslationMap(
+  vtkMRMLMarkupsNode* markupsNode, TranslationMap& markupsMap)
+{
+  if (!markupsNode)
+    {
+    return 0;
+    }
+
+  int success = 1;
+
+  // Locked
+  markupsMap["/Locked"] = markupsNode->GetLocked();
+  // MarkupLabelFormat
+  markupsMap["/MarkupLabelFormat"] = markupsNode->GetMarkupLabelFormat().c_str();
+  // TextList
+  markupsMap["/TextList_Count"] = markupsNode->GetNumberOfTexts();
+  if (markupsNode->GetNumberOfTexts() == 0)
+    {
+    // Empty variant to signal that the list is empty
+    markupsMap["/TextList/0"] = vtkVariant();
+    }
+  else
+    {
+    for (int i = 0; i < markupsNode->GetNumberOfTexts(); ++i)
+      {
+      std::stringstream key;
+      key << "/TextList/" << i;
+      markupsMap[key.str().c_str()] = markupsNode->GetText(i);
+      }
+    }
+  // Markups
+  markupsMap["/Markups_Count"] = markupsNode->GetNumberOfMarkups();
+  if (markupsNode->GetNumberOfMarkups() == 0)
+    {
+    // Empty variant to signal that the list is empty
+    markupsMap["/Markups/0"] = vtkVariant();
+    }
+  else
+    {
+    for (int i = 0; i < markupsNode->GetNumberOfMarkups(); ++i)
+      {
+      std::stringstream subKey;
+      subKey << "/Markups/" << i << "/";
+
+      success &= this->WriteNthMarkupToTranslationMap(
+        i, subKey.str(), markupsNode, markupsMap);
+      }
+    }
+
+  return success;
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLMarkupsGenericStorageNode::WriteNthMarkupToTranslationMap(
+  int n, std::string key,
+  vtkMRMLMarkupsNode* markupsNode, TranslationMap& markupsMap)
+{
+  if (!markupsNode || !markupsNode->MarkupExists(n))
+    {
+    return 0;
+    }
+
+  Markup* markup = markupsNode->GetNthMarkup(n);
+
+  // ID
+  markupsMap[key + "ID"] = markup->ID.c_str();
+  // Label
+  markupsMap[key + "Label"] = markup->Label.c_str();
+  // Description
+  markupsMap[key + "Description"] = markup->Description.c_str();
+  // AssociatedNodeID
+  markupsMap[key + "AssociatedNodeID"] = markup->AssociatedNodeID.c_str();
+  // Points
+  markupsMap[key + "Points_Count"] = markup->points.size();
+  if (markup->points.size() == 0)
+    {
+    // Empty variant to signal that the list is empty
+    markupsMap[key + "Points/0"] = vtkVariant();
+    }
+  else
+    {
+    for (size_t i = 0; i < markup->points.size(); ++i)
+      {
+      std::stringstream pointsKey;
+      pointsKey << key << "Points/" << i << "/x";
+      markupsMap[pointsKey.str()] = markup->points[i][0];
+      pointsKey.str("");
+      pointsKey << key << "Points/" << i << "/y";
+      markupsMap[pointsKey.str()] = markup->points[i][1];
+      pointsKey.str("");
+      pointsKey << key << "Points/" << i << "/z";
+      markupsMap[pointsKey.str()] = markup->points[i][2];
+      }
+    }
+
+  // OrientationWXYZ
+  for (int i = 0; i < 4; ++i)
+    {
+    std::stringstream orientationKey;
+    orientationKey << key << "OrientationWXYZ/" << i;
+    markupsMap[orientationKey.str()] = markup->OrientationWXYZ[i];
+    }
+
+  // NOTE: vtkVariant stores bool as a char, which gives weird result in JSON.
+  // -> Force the bool to int.
+  // Selected
+  markupsMap[key + "Selected"] = static_cast<unsigned int>(markup->Selected);
+  // Selected
+  markupsMap[key + "Locked"] = static_cast<unsigned int>(markup->Locked);
+  // Selected
+  markupsMap[key + "Visibility"] = static_cast<unsigned int>(markup->Visibility);
+
+  return 1;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsGenericStorageNode::InitializeSupportedReadFileTypes()
+{
+  this->SupportedReadFileTypes->InsertNextValue("Markups (.markups.json)");
+  this->SupportedReadFileTypes->InsertNextValue("Markups (.json)");
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsGenericStorageNode::InitializeSupportedWriteFileTypes()
+{
+  this->SupportedWriteFileTypes->InsertNextValue("Markups (.markups.json)");
+  this->SupportedWriteFileTypes->InsertNextValue("Markups (.json)");
+}

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsGenericStorageNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsGenericStorageNode.h
@@ -1,0 +1,111 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Johan Andruejol, Kitware Inc.
+  and was partially funded by Allen Institute.
+
+==============================================================================*/
+
+/// Markups Module MRML storage nodes
+///
+/// vtkMRMLMarkupsGenericStorageNode - MRML node for markups storage
+///
+/// vtkMRMLMarkupsGenericStorageNode nodes describe the markups storage
+/// node that allows to read/write fiducial point data from/to JSON.
+
+#ifndef __vtkMRMLMarkupsGenericStorageNode_h
+#define __vtkMRMLMarkupsGenericStorageNode_h
+
+// Markups includes
+#include "vtkSlicerMarkupsModuleMRMLExport.h"
+#include "vtkMRMLMarkupsStorageNode.h"
+
+class vtkMRMLMarkupsNode;
+
+/// \ingroup Slicer_QtModules_Markups
+class VTK_SLICER_MARKUPS_MODULE_MRML_EXPORT vtkMRMLMarkupsGenericStorageNode
+  : public vtkMRMLMarkupsStorageNode
+{
+public:
+  static vtkMRMLMarkupsGenericStorageNode *New();
+  vtkTypeMacro(vtkMRMLMarkupsGenericStorageNode,vtkMRMLMarkupsStorageNode);
+
+  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
+
+  ///
+  /// Get node XML tag name (like Storage, Model)
+  virtual const char* GetNodeTagName() VTK_OVERRIDE {return "MarkupGenericStorage";};
+
+  virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode) VTK_OVERRIDE;
+
+protected:
+  vtkMRMLMarkupsGenericStorageNode();
+  ~vtkMRMLMarkupsGenericStorageNode();
+  vtkMRMLMarkupsGenericStorageNode(const vtkMRMLMarkupsGenericStorageNode&);
+  void operator=(const vtkMRMLMarkupsGenericStorageNode&);
+
+  /// Initialize all the supported write file types
+  virtual void InitializeSupportedReadFileTypes() VTK_OVERRIDE;
+
+  /// Initialize all the supported write file types
+  virtual void InitializeSupportedWriteFileTypes() VTK_OVERRIDE;
+
+  /// Read data and set it in the referenced node
+  virtual int ReadDataInternal(vtkMRMLNode *refNode) VTK_OVERRIDE;
+
+  /// Write data from a  referenced node.
+  virtual int WriteDataInternal(vtkMRMLNode *refNode) VTK_OVERRIDE;
+
+  /// The translation map is used read from/to JSON and filled
+  /// with the markup properties.
+  /// The keys follow the RapidJSON pointer usage
+  /// (http://rapidjson.org/md_doc_pointer.html#BasicUsage)
+  typedef std::map<std::string, vtkVariant> TranslationMap;
+
+  /// Use Read/WriteMarkupsNodeFromTranslationMap to add properties that will
+  /// be read/written for the node. For example, the MarkupLabelFormat is
+  /// added here with the key "/MarkupLabelFormat".
+  /// For lists, it is also expected to add the property *_Count that contains
+  /// the size of the list.
+  /// If the list is empty, you must add a empty vtkVariant() to it. Use a
+  /// key that follows this format "/MyListKeyName/0".
+  /// \sa TranslationMap()
+  virtual int ReadMarkupsNodeFromTranslationMap(
+    vtkMRMLMarkupsNode* markups, TranslationMap& markupsMap);
+
+  /// Use Read/WriteNthMarkupFromTranslationMap to add properties that will
+  /// be read/written for each of the node's markups. For example, the
+  /// OrientationWXYZ property of each markup is added here.
+  /// \sa TranslationMap()
+  /// \sa ReadMarkupsNodeFromTranslationMap()
+  virtual int ReadNthMarkupFromTranslationMap(
+    int n, std::string key,
+    vtkMRMLMarkupsNode* markups, TranslationMap& markupsMap);
+
+  /// \sa ReadMarkupsNodeFromTranslationMap()
+  virtual int WriteMarkupsNodeToTranslationMap(
+    vtkMRMLMarkupsNode* markups, TranslationMap& markupsMap);
+
+  /// \sa ReadNthMarkupFromTranslationMap()
+  virtual int WriteNthMarkupToTranslationMap(
+    int n, std::string key,
+    vtkMRMLMarkupsNode* markups, TranslationMap& markupsMap);
+
+  class vtkInternal;
+  vtkInternal* Internal;
+  friend class vtkInternal;
+};
+
+#endif

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -20,6 +20,7 @@
 #include "vtkMRMLMarkupsDisplayNode.h"
 #include "vtkMRMLMarkupsNode.h"
 #include "vtkMRMLMarkupsStorageNode.h"
+#include "vtkMRMLMarkupsGenericStorageNode.h"
 #include "vtkMRMLTransformNode.h"
 
 // Slicer MRML includes
@@ -345,7 +346,7 @@ void vtkMRMLMarkupsNode::RemoveAllTexts()
 //-------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLMarkupsNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLStorageNode::SafeDownCast(vtkMRMLMarkupsStorageNode::New());
+  return vtkMRMLStorageNode::SafeDownCast(vtkMRMLMarkupsGenericStorageNode::New());
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/Resources/GenericStorage.markups.json
+++ b/Modules/Loadable/Markups/Resources/GenericStorage.markups.json
@@ -1,0 +1,29 @@
+{
+  "Locked":0,
+  "MarkupLabelFormat":"%N-%d",
+  "Markups":
+    [
+      {
+      "AssociatedNodeID":"",
+      "Description":"",
+      "ID":"vtkMRMLMarkupsNode_0",
+      "Label":"Markups-1",
+      "Locked":0,
+      "OrientationWXYZ":[0.0, 0.0, 0.0, 1.0],
+      "Points":
+        [
+          {
+          "x":0.0,
+          "y":0.0,
+          "z":0.0
+          }
+        ],
+      "Points_Count":"1",
+      "Selected":1,
+      "Visibility":1
+    }
+  ],
+  "Markups_Count":1,
+  "TextList":[null],
+  "TextList_Count":0
+}

--- a/Modules/Loadable/Markups/Testing/Python/CMakeLists.txt
+++ b/Modules/Loadable/Markups/Testing/Python/CMakeLists.txt
@@ -41,3 +41,12 @@ slicerMacroBuildScriptedModule(
   )
 slicer_add_python_unittest(SCRIPT MarkupsInViewsSelfTest.py
                            SLICER_ARGS --disable-cli-modules)
+
+# Test generic markup storage node
+slicerMacroBuildScriptedModule(
+  NAME MarkupsGenericStorageTest
+  SCRIPTS MarkupsGenericStorageTest.py
+  RESOURCES ${MARKUPS_PYTHON_RESOURCES}
+  )
+slicer_add_python_unittest(SCRIPT MarkupsGenericStorageTest.py
+                           SLICER_ARGS --disable-cli-modules)

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsGenericStorageTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsGenericStorageTest.py
@@ -1,0 +1,178 @@
+import os
+import time
+import unittest
+from __main__ import vtk, qt, ctk, slicer
+from slicer.ScriptedLoadableModule import *
+import json
+
+#
+# MarkupsGenericStorageTest
+#
+
+class MarkupsGenericStorageTest(ScriptedLoadableModule):
+  def __init__(self, parent):
+    parent.title = "MarkupsGenericStorageTest"
+    parent.categories = ["Testing.TestCases"]
+    parent.dependencies = []
+    parent.contributors = ["Johan Andruejol (Kitware Inc."]
+    parent.helpText = """
+    This is a test for the Generic Markups Storage NOde
+    """
+    parent.acknowledgementText = """
+    This file was originally developed by Johan Andruejol and was partially funded by Allen Institute".
+""" # replace with organization, grant and thanks.
+    self.parent = parent
+
+    # Add this test to the SelfTest module's list for discovery when the module
+    # is created.  Since this module may be discovered before SelfTests itself,
+    # create the list if it doesn't already exist.
+    try:
+      slicer.selfTests
+    except AttributeError:
+      slicer.selfTests = {}
+    slicer.selfTests['MarkupsGenericStorageTest'] = self.runTest
+
+  def runTest(self):
+    tester = MarkupsGenericStorageTestTest()
+    tester.runTest()
+
+#
+# qMarkupsGenericStorageTestWidget
+#
+
+class MarkupsGenericStorageTestWidget(ScriptedLoadableModuleWidget):
+
+  def setup(self):
+    ScriptedLoadableModuleWidget.setup(self)
+
+#
+# MarkupsGenericStorageTestLogic
+#
+
+class MarkupsGenericStorageTestLogic(ScriptedLoadableModuleLogic):
+
+  def __init__(self):
+    pass
+
+#
+# MarkupsGenericStorageTestTest
+#
+
+class MarkupsGenericStorageTestTest(ScriptedLoadableModuleTest):
+
+  def setUp(self):
+    """ Reset the state for testing.
+    """
+    slicer.mrmlScene.Clear(0)
+
+  def runTest(self):
+    """Run as few or as many tests as needed here.
+    """
+    self.setUp()
+    self.test_MarkupsGenericStorageTest1()
+    self.test_MarkupsGenericStorageTest2()
+
+  def saveAndReload(self, markup):
+    self.assertIsNone(markup.GetStorageNode())
+
+    self.assertTrue(markup.AddDefaultStorageNode())
+    storage = markup.GetStorageNode()
+    self.assertIsNotNone(storage)
+    self.assertTrue(storage.IsA('vtkMRMLMarkupsGenericStorageNode'))
+
+    tempFile = qt.QTemporaryFile("test-MarkupsGenericStorageTest-XXXXXX.markups.json")
+    self.assertTrue(tempFile.open())
+
+    slicer.util.saveNode(markup, tempFile.fileName())
+    slicer.mrmlScene.Clear(0)
+
+    # Make sure it can be read by python json
+    file = open(tempFile.fileName())
+    data = json.load(file)
+    markupsKeys = [
+      'Locked',
+      'MarkupLabelFormat',
+      'TextList',
+      'TextList_Count',
+      'Markups',
+      'Markups_Count',
+      ]
+    for markupsKey in markupsKeys:
+      self.assertTrue(markupsKey in data.keys(), msg="Checking for key %s" %markupsKey)
+
+    for i in range(int(data['Markups_Count'])):
+      markupSubKeys = [
+        'ID',
+        'Label',
+        'Description',
+        'AssociatedNodeID',
+        'Points',
+        'OrientationWXYZ',
+        'Selected',
+        'Locked',
+        'Visibility',
+        ]
+      for subKey in markupSubKeys:
+        self.assertTrue(subKey in data['Markups'][i].keys(), msg="Checking for sub key %s" %subKey)
+
+    loaded = slicer.util.loadNodeFromFile(tempFile.fileName(), 'Markups', returnNode=True)
+    self.assertTrue(loaded[0])
+    self.assertIsNotNone(loaded[1])
+    self.assertTrue(loaded[1].IsA('vtkMRMLMarkupsNode'))
+    return loaded[1]
+
+
+  def test_MarkupsGenericStorageTest1(self):
+    self.delayDisplay("Starting testing the generic markups storage test 1")
+
+    # Write markup to file
+    markup = slicer.mrmlScene.AddNode(slicer.vtkMRMLMarkupsNode())
+    newMarkup = self.saveAndReload(markup)
+
+    self.assertEqual(newMarkup.GetLocked(), 0)
+    self.assertEqual(newMarkup.GetMarkupLabelFormat(), '%N-%d')
+    self.assertEqual(newMarkup.GetNumberOfTexts(), 0)
+    self.assertEqual(newMarkup.GetNumberOfMarkups(), 0)
+
+    self.delayDisplay('Test passed!')
+
+
+  def test_MarkupsGenericStorageTest2(self):
+    self.delayDisplay("Starting testing the generic markups storage test 2")
+
+    # Write markup to file
+    markup = slicer.mrmlScene.AddNode(slicer.vtkMRMLMarkupsNode())
+    markup.SetLocked(1)
+    markup.SetMarkupLabelFormat('THIS IS A TEST !')
+    markup.AddText('And this is too')
+    markup.AddText('finale line')
+
+    markup.AddPointToNewMarkup(vtk.vtkVector3d(0, 0, 0))
+    markup.SetNthMarkupLabel(0, "First markup")
+    markup.SetNthMarkupDescription(0, "This is the description of the first markup")
+    markup.SetNthMarkupAssociatedNodeID(0, 'vtkMRMLSliceNodeRed')
+    markup.SetNthMarkupOrientation(0, 0, 1, 2, 3)
+    markup.SetNthMarkupSelected(0, 1)
+    markup.SetNthMarkupLocked(0, 1)
+    markup.SetNthMarkupVisibility(0, 1)
+
+    newMarkup = self.saveAndReload(markup)
+
+    self.assertEqual(newMarkup.GetLocked(), 1)
+    self.assertEqual(newMarkup.GetMarkupLabelFormat(), 'THIS IS A TEST !')
+    self.assertEqual(newMarkup.GetNumberOfTexts(), 2)
+    self.assertEqual(newMarkup.GetText(0), 'And this is too')
+    self.assertEqual(newMarkup.GetText(1), 'finale line')
+
+    self.assertEqual(newMarkup.GetNumberOfMarkups(), 1)
+    self.assertEqual(newMarkup.GetNthMarkupLabel(0), "First markup")
+    self.assertEqual(newMarkup.GetNthMarkupDescription(0), "This is the description of the first markup")
+    self.assertEqual(newMarkup.GetNthMarkupAssociatedNodeID(0), 'vtkMRMLSliceNodeRed')
+    orientation = range(4)
+    newMarkup.GetNthMarkupOrientation(0, orientation)
+    self.assertListEqual(orientation, [0, 1, 2, 3])
+    self.assertEqual(newMarkup.GetNthMarkupSelected(0), 1)
+    self.assertEqual(newMarkup.GetNthMarkupLocked(0), 1)
+    self.assertEqual(newMarkup.GetNthMarkupVisibility(0), 1)
+
+    self.delayDisplay('Test passed!')

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsGenericStorageTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsGenericStorageTest.py
@@ -71,6 +71,7 @@ class MarkupsGenericStorageTestTest(ScriptedLoadableModuleTest):
     self.setUp()
     self.test_MarkupsGenericStorageTest1()
     self.test_MarkupsGenericStorageTest2()
+    self.test_MarkupsGenericStorageTest3()
 
   def saveAndReload(self, markup):
     self.assertIsNone(markup.GetStorageNode())
@@ -174,5 +175,39 @@ class MarkupsGenericStorageTestTest(ScriptedLoadableModuleTest):
     self.assertEqual(newMarkup.GetNthMarkupSelected(0), 1)
     self.assertEqual(newMarkup.GetNthMarkupLocked(0), 1)
     self.assertEqual(newMarkup.GetNthMarkupVisibility(0), 1)
+
+    self.delayDisplay('Test passed!')
+
+
+  def test_MarkupsGenericStorageTest3(self):
+    self.delayDisplay("Starting testing the generic markups storage test 3")
+
+    # Write markup to file
+    markup = slicer.mrmlScene.AddNode(slicer.vtkMRMLMarkupsNode())
+    markup.AddPointToNewMarkup(vtk.vtkVector3d(0, 0, 0))
+
+    logic = slicer.modules.markups.logic()
+    defaultMarkupJSON = logic.GetModuleShareDirectory() + '/GenericStorage.markups.json'
+    loaded = slicer.util.loadNodeFromFile(defaultMarkupJSON, 'Markups', returnNode=True)
+    self.assertTrue(loaded[0])
+    newMarkup = loaded[1]
+    self.assertIsNotNone(newMarkup)
+
+    self.assertEqual(markup.GetLocked(), newMarkup.GetLocked())
+    self.assertEqual(markup.GetMarkupLabelFormat(), newMarkup.GetMarkupLabelFormat())
+    self.assertEqual(markup.GetNumberOfTexts(), newMarkup.GetNumberOfTexts())
+
+    self.assertEqual(markup.GetNumberOfMarkups(), newMarkup.GetNumberOfMarkups())
+    self.assertEqual(markup.GetNthMarkupLabel(0), newMarkup.GetNthMarkupLabel(0))
+    self.assertEqual(markup.GetNthMarkupDescription(0), newMarkup.GetNthMarkupDescription(0))
+    self.assertEqual(markup.GetNthMarkupAssociatedNodeID(0), newMarkup.GetNthMarkupAssociatedNodeID(0))
+    orientation = range(4)
+    markup.GetNthMarkupOrientation(0, orientation)
+    newOrientation = range(4)
+    newMarkup.GetNthMarkupOrientation(0, newOrientation)
+    self.assertListEqual(orientation, newOrientation)
+    self.assertEqual(markup.GetNthMarkupSelected(0), newMarkup.GetNthMarkupSelected(0))
+    self.assertEqual(markup.GetNthMarkupLocked(0), newMarkup.GetNthMarkupLocked(0))
+    self.assertEqual(markup.GetNthMarkupVisibility(0), newMarkup.GetNthMarkupVisibility(0))
 
     self.delayDisplay('Test passed!')

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsGenericStorageTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsGenericStorageTest.py
@@ -116,7 +116,7 @@ class MarkupsGenericStorageTestTest(ScriptedLoadableModuleTest):
       for subKey in markupSubKeys:
         self.assertTrue(subKey in data['Markups'][i].keys(), msg="Checking for sub key %s" %subKey)
 
-    loaded = slicer.util.loadNodeFromFile(tempFile.fileName(), 'Markups', returnNode=True)
+    loaded = slicer.util.loadMarkups(tempFile.fileName(), returnNode=True)
     self.assertTrue(loaded[0])
     self.assertIsNotNone(loaded[1])
     self.assertTrue(loaded[1].IsA('vtkMRMLMarkupsNode'))
@@ -188,7 +188,7 @@ class MarkupsGenericStorageTestTest(ScriptedLoadableModuleTest):
 
     logic = slicer.modules.markups.logic()
     defaultMarkupJSON = logic.GetModuleShareDirectory() + '/GenericStorage.markups.json'
-    loaded = slicer.util.loadNodeFromFile(defaultMarkupJSON, 'Markups', returnNode=True)
+    loaded = slicer.util.loadMarkups(defaultMarkupJSON, returnNode=True)
     self.assertTrue(loaded[0])
     newMarkup = loaded[1]
     self.assertIsNotNone(newMarkup)

--- a/Modules/Loadable/Markups/qSlicerMarkupsFiducialsReader.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsFiducialsReader.cxx
@@ -1,0 +1,70 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// SlicerQt includes
+#include "qSlicerMarkupsFiducialsReader.h"
+
+// Logic includes
+#include "vtkSlicerMarkupsLogic.h"
+
+//-----------------------------------------------------------------------------
+/// \ingroup Slicer_QtModules_Annotations
+//-----------------------------------------------------------------------------
+qSlicerMarkupsFiducialsReader::qSlicerMarkupsFiducialsReader(QObject* _parent)
+  : Superclass(_parent)
+{
+}
+
+//-----------------------------------------------------------------------------
+qSlicerMarkupsFiducialsReader
+::qSlicerMarkupsFiducialsReader(vtkSlicerMarkupsLogic* logic, QObject* _parent)
+  : Superclass(logic, _parent)
+{
+}
+
+//-----------------------------------------------------------------------------
+qSlicerMarkupsFiducialsReader::~qSlicerMarkupsFiducialsReader()
+{
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerMarkupsFiducialsReader::description()const
+{
+  return "MarkupsFiducials";
+}
+
+//-----------------------------------------------------------------------------
+qSlicerIO::IOFileType qSlicerMarkupsFiducialsReader::fileType()const
+{
+  return QString("MarkupsFiducials");
+}
+
+//-----------------------------------------------------------------------------
+QStringList qSlicerMarkupsFiducialsReader::extensions()const
+{
+  return QStringList()
+    << "Markups Fiducials (*.fcsv)"
+    << " Annotation Fiducial (*.acsv)";
+}
+
+//-----------------------------------------------------------------------------
+char* qSlicerMarkupsFiducialsReader
+::load(const QString& filename, const QString& name)
+{
+  return this->markupsLogic()->LoadMarkupsFiducials(
+    filename.toLatin1(), name.toLatin1());
+}

--- a/Modules/Loadable/Markups/qSlicerMarkupsFiducialsReader.h
+++ b/Modules/Loadable/Markups/qSlicerMarkupsFiducialsReader.h
@@ -15,44 +15,33 @@
 
 ==============================================================================*/
 
-#ifndef __qSlicerMarkupsReader_h
-#define __qSlicerMarkupsReader_h
+#ifndef __qSlicerMarkupsFiducialsReader_h
+#define __qSlicerMarkupsFiducialsReader_h
 
 // SlicerQt includes
-#include "qSlicerFileReader.h"
-
-class qSlicerMarkupsReaderPrivate;
-class vtkSlicerMarkupsLogic;
+#include "qSlicerMarkupsReader.h"
 
 //----------------------------------------------------------------------------
 /// \ingroup Slicer_QtModules_Markups
-class qSlicerMarkupsReader
-  : public qSlicerFileReader
+class qSlicerMarkupsFiducialsReader
+  : public qSlicerMarkupsReader
 {
   Q_OBJECT
 public:
-  typedef qSlicerFileReader Superclass;
-  qSlicerMarkupsReader(QObject* parent = 0);
-  qSlicerMarkupsReader(vtkSlicerMarkupsLogic* logic, QObject* parent = 0);
-  virtual ~qSlicerMarkupsReader();
-
-  vtkSlicerMarkupsLogic* markupsLogic()const;
-  void setMarkupsLogic(vtkSlicerMarkupsLogic* logic);
+  typedef qSlicerMarkupsReader Superclass;
+  qSlicerMarkupsFiducialsReader(QObject* parent = 0);
+  qSlicerMarkupsFiducialsReader(vtkSlicerMarkupsLogic* logic, QObject* parent = 0);
+  virtual ~qSlicerMarkupsFiducialsReader();
 
   virtual QString description()const;
   virtual IOFileType fileType()const;
   virtual QStringList extensions()const;
 
-  virtual bool load(const IOProperties& properties);
-
 protected:
-  QScopedPointer<qSlicerMarkupsReaderPrivate> d_ptr;
-
   virtual char* load(const QString& filename, const QString& name);
 
 private:
-  Q_DECLARE_PRIVATE(qSlicerMarkupsReader);
-  Q_DISABLE_COPY(qSlicerMarkupsReader);
+  Q_DISABLE_COPY(qSlicerMarkupsFiducialsReader);
 };
 
 #endif

--- a/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
@@ -36,6 +36,7 @@
 #include "qSlicerSubjectHierarchyMarkupsPlugin.h"
 
 // Markups includes
+#include "qSlicerMarkupsFiducialsReader.h"
 #include "qSlicerMarkupsModule.h"
 #include "qSlicerMarkupsModuleWidget.h"
 #include "qSlicerMarkupsReader.h"
@@ -135,11 +136,20 @@ void qSlicerMarkupsModule::setup()
 
   // Register IO
   qSlicerIOManager* ioManager = qSlicerApplication::application()->ioManager();
-  qSlicerMarkupsReader *markupsIO = new qSlicerMarkupsReader(vtkSlicerMarkupsLogic::SafeDownCast(this->logic()), this);
+  // Readers
+  qSlicerMarkupsReader *markupsIO =
+    new qSlicerMarkupsReader(vtkSlicerMarkupsLogic::SafeDownCast(this->logic()), this);
   ioManager->registerIO(markupsIO);
+  qSlicerMarkupsFiducialsReader *markupsFiducialIO =
+    new qSlicerMarkupsFiducialsReader(vtkSlicerMarkupsLogic::SafeDownCast(this->logic()), this);
+  ioManager->registerIO(markupsFiducialIO);
+  // Writers
   ioManager->registerIO(new qSlicerNodeWriter(
-                            "MarkupsFiducials", markupsIO->fileType(),
-                            QStringList() << "vtkMRMLMarkupsNode", true, this));
+    "Markups", markupsIO->fileType(),
+    QStringList() << "vtkMRMLMarkupsNode", true, this));
+  ioManager->registerIO(new qSlicerNodeWriter(
+    "MarkupsFiducials", markupsFiducialIO->fileType(),
+    QStringList() << "vtkMRMLMarkupsFiducialsNode", true, this));
 
   // settings
   /*

--- a/Modules/Loadable/Markups/qSlicerMarkupsReader.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsReader.cxx
@@ -76,21 +76,25 @@ vtkSlicerMarkupsLogic* qSlicerMarkupsReader::markupsLogic()const
 //-----------------------------------------------------------------------------
 QString qSlicerMarkupsReader::description()const
 {
-  return "MarkupsFiducials";
+  return "Markups";
 }
 
 //-----------------------------------------------------------------------------
 qSlicerIO::IOFileType qSlicerMarkupsReader::fileType()const
 {
-  return QString("MarkupsFiducials");
+  return QString("Markups");
 }
 
 //-----------------------------------------------------------------------------
 QStringList qSlicerMarkupsReader::extensions()const
 {
-  return QStringList()
-    << "Markups Fiducials (*.fcsv)"
-    << " Annotation Fiducial (*.acsv)";
+  return QStringList() << "Markups (*.markups.json)" << "Markups (*.json)";
+}
+
+//-----------------------------------------------------------------------------
+char* qSlicerMarkupsReader::load(const QString& filename, const QString& name)
+{
+  return this->markupsLogic()->LoadMarkups(filename.toLatin1(), name.toLatin1());
 }
 
 //-----------------------------------------------------------------------------
@@ -114,7 +118,7 @@ bool qSlicerMarkupsReader::load(const IOProperties& properties)
     }
 
   // pass to logic to do the loading
-  char * nodeIDs = d->MarkupsLogic->LoadMarkupsFiducials(fileName.toLatin1(), name.toLatin1());
+  char * nodeIDs = this->load(fileName, name);
 
   if (nodeIDs)
     {


### PR DESCRIPTION
Markups did not have a generic storage node that worked for all for types
of markups. This new storage nodes aims to fill this need. It is also meant
to be easily extensible in potential markup subclasses.

The new generic storage exports markups to JSON for ease of interface with
the web, python and other applications.

The existing Markups Fiducial reader is left as-is and is still the default
for fiducials.

CC: @jcfr