### PR TITLE
ENH: Add vtkMRMLStorageNode CompressionParameter and presets

### DIFF
--- a/Base/QTGUI/Resources/UI/qSlicerNodeWriterOptionsWidget.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerNodeWriterOptionsWidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>94</width>
+    <width>145</width>
     <height>17</height>
    </rect>
   </property>
@@ -21,6 +21,16 @@
     <widget class="QCheckBox" name="UseCompressionCheckBox">
      <property name="text">
       <string>Compress</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QComboBox" name="CompressionParameterSelector">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
     </widget>
    </item>

--- a/Base/QTGUI/qSlicerNodeWriter.cxx
+++ b/Base/QTGUI/qSlicerNodeWriter.cxx
@@ -156,6 +156,10 @@ bool qSlicerNodeWriter::write(const qSlicerIO::IOProperties& properties)
   if (properties.contains("useCompression"))
     {
     snode->SetUseCompression(properties["useCompression"].toInt());
+    if (properties.contains("compressionParameter"))
+      {
+      snode->SetCompressionParameter(properties["compressionParameter"].toString().toStdString());
+      }
     }
   bool res = snode->WriteData(node);
 

--- a/Base/QTGUI/qSlicerNodeWriterOptionsWidget.cxx
+++ b/Base/QTGUI/qSlicerNodeWriterOptionsWidget.cxx
@@ -50,6 +50,8 @@ void qSlicerNodeWriterOptionsWidgetPrivate::setupUi(QWidget* widget)
   this->Ui_qSlicerNodeWriterOptionsWidget::setupUi(widget);
   QObject::connect(this->UseCompressionCheckBox, SIGNAL(toggled(bool)),
                    widget, SLOT(setUseCompression(bool)));
+  QObject::connect(this->CompressionParameterSelector, SIGNAL(currentIndexChanged(int)),
+                   widget, SLOT(setCompressionParameter(int)));
 }
 
 //------------------------------------------------------------------------------
@@ -92,7 +94,20 @@ void qSlicerNodeWriterOptionsWidget::setObject(vtkObject* object)
     {
     d->UseCompressionCheckBox->setChecked(
       (storageNode->GetUseCompression() == 1));
+
+    std::vector<vtkMRMLStorageNode::CompressionPreset> presets = storageNode->GetCompressionPresets();
+    d->CompressionParameterSelector->clear();
+    std::vector<vtkMRMLStorageNode::CompressionPreset>::iterator presetIt;
+    for (presetIt = presets.begin(); presetIt != presets.end(); ++presetIt)
+      {
+      QString name = QString::fromStdString(presetIt->Name);
+      QString parameter = QString::fromStdString(presetIt->Parameter);
+      d->CompressionParameterSelector->addItem(name, parameter);
+      }
+    this->setCompressionParameter(QString::fromStdString(storageNode->GetCompressionParameter()));
     }
+  d->CompressionParameterSelector->setVisible(d->CompressionParameterSelector->count() > 0);
+  d->CompressionParameterSelector->setEnabled(storageNode != 0 && d->UseCompressionCheckBox->isChecked());
 
   this->updateValid();
 }
@@ -102,6 +117,7 @@ void qSlicerNodeWriterOptionsWidget::setUseCompression(bool use)
 {
   Q_D(qSlicerNodeWriterOptionsWidget);
   d->Properties["useCompression"] = (use ? 1 : 0);
+  d->CompressionParameterSelector->setEnabled(d->UseCompressionCheckBox->isChecked());
 }
 
 //------------------------------------------------------------------------------
@@ -116,5 +132,25 @@ bool qSlicerNodeWriterOptionsWidget::showUseCompression()const
 void qSlicerNodeWriterOptionsWidget::setShowUseCompression(bool show)
 {
   Q_D(qSlicerNodeWriterOptionsWidget);
-  return d->UseCompressionCheckBox->setVisible(show);
+  d->UseCompressionCheckBox->setVisible(show);
+  d->CompressionParameterSelector->setVisible(show && d->CompressionParameterSelector->count() > 0);
+}
+
+//------------------------------------------------------------------------------
+void qSlicerNodeWriterOptionsWidget::setCompressionParameter(int index)
+{
+  Q_D(qSlicerNodeWriterOptionsWidget);
+
+  QString parameter = d->CompressionParameterSelector->itemData(index).toString();
+  d->Properties["compressionParameter"] = parameter;
+}
+
+//------------------------------------------------------------------------------
+void qSlicerNodeWriterOptionsWidget::setCompressionParameter(QString parameter)
+{
+  Q_D(qSlicerNodeWriterOptionsWidget);
+
+  int index = d->CompressionParameterSelector->findData(parameter);
+  d->CompressionParameterSelector->setCurrentIndex(index);
+  d->Properties["compressionParameter"] = parameter;
 }

--- a/Base/QTGUI/qSlicerNodeWriterOptionsWidget.h
+++ b/Base/QTGUI/qSlicerNodeWriterOptionsWidget.h
@@ -47,6 +47,8 @@ public slots:
 
 protected slots:
   virtual void setUseCompression(bool use);
+  virtual void setCompressionParameter(int index);
+  virtual void setCompressionParameter(QString parameter);
 
 private:
   Q_DECLARE_PRIVATE_D(qGetPtrHelper(qSlicerIOOptions::d_ptr), qSlicerNodeWriterOptionsWidget);

--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -26,6 +26,7 @@
 #include <QMessageBox>
 #include <QRegExp>
 #include <QRegExpValidator>
+#include <QSettings>
 
 /// CTK includes
 #include <ctkCheckableHeaderView.h>
@@ -191,6 +192,13 @@ qSlicerSaveDataDialogPrivate::qSlicerSaveDataDialogPrivate(QWidget* parentWidget
           this, SLOT(saveSceneAsDataBundle()));
   connect(this->ShowMoreCheckBox, SIGNAL(toggled(bool)),
           this, SLOT(showMoreColumns(bool)));
+
+  if (!qSlicerApplication::application()->userSettings()->contains("QSlicerSaveDataDialog/ShowMore"))
+  {
+    qSlicerApplication::application()->userSettings()->setValue("QSlicerSaveDataDialog/ShowMore", false);
+  }
+  this->ShowMoreCheckBox->setChecked(
+    qSlicerApplication::application()->userSettings()->value("QSlicerSaveDataDialog/ShowMore").toBool());
   this->showMoreColumns(this->ShowMoreCheckBox->isChecked());
 }
 
@@ -1311,6 +1319,8 @@ void qSlicerSaveDataDialogPrivate::showMoreColumns(bool show)
   this->FileWidget->setColumnHidden(NodeTypeColumn, !show);
   this->FileWidget->setColumnHidden(NodeStatusColumn, !show);
   this->updateSize();
+
+  qSlicerApplication::application()->userSettings()->setValue("QSlicerSaveDataDialog/ShowMore", show);
 }
 
 //-----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLNRRDStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLNRRDStorageNode.cxx
@@ -43,6 +43,7 @@ vtkMRMLNRRDStorageNode::vtkMRMLNRRDStorageNode()
 {
   this->CenterImage = 0;
   this->DefaultWriteFileExtension = "nhdr";
+  this->CompressionParameter = this->GetNRRDCompressionPresetLow();
 }
 
 //----------------------------------------------------------------------------
@@ -369,7 +370,7 @@ int vtkMRMLNRRDStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
   writer->SetFileName(fullName.c_str());
   writer->SetInputConnection(volNode->GetImageDataConnection());
   writer->SetUseCompression(this->GetUseCompression());
-  writer->SetCompressionLevel(this->GetCompressionLevel());
+  writer->SetCompressionLevel(this->ConvertNRRDCompressionParameterToInt(this->CompressionParameter));
 
   // set volume attributes
   writer->SetIJKToRASMatrix(ijkToRas.GetPointer());
@@ -578,6 +579,45 @@ void vtkMRMLNRRDStorageNode::InitializeSupportedWriteFileTypes()
 {
   this->SupportedWriteFileTypes->InsertNextValue("NRRD (.nrrd)");
   this->SupportedWriteFileTypes->InsertNextValue("NRRD (.nhdr)");
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLNRRDStorageNode::InitializeCompressionPresets()
+{
+  this->CompressionPresets.clear();
+
+  vtkMRMLStorageNode::CompressionPreset compressionLevelLow;
+  compressionLevelLow.Name = "Low";
+  compressionLevelLow.Parameter = this->GetNRRDCompressionPresetLow();
+  this->CompressionPresets.push_back(compressionLevelLow);
+
+  vtkMRMLStorageNode::CompressionPreset compressionLevelMedium;
+  compressionLevelMedium.Name = "Medium";
+  compressionLevelMedium.Parameter = this->GetNRRDCompressionPresetMedium();
+  this->CompressionPresets.push_back(compressionLevelMedium);
+
+  vtkMRMLStorageNode::CompressionPreset compressionLevelHigh;
+  compressionLevelHigh.Name = "High";
+  compressionLevelHigh.Parameter = this->GetNRRDCompressionPresetHigh();
+  this->CompressionPresets.push_back(compressionLevelHigh);
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLNRRDStorageNode::ConvertNRRDCompressionParameterToInt(std::string compressionParameter)
+{
+  if (compressionParameter == this->GetNRRDCompressionPresetLow())
+    {
+    return 1;
+    }
+  else if(compressionParameter == this->GetNRRDCompressionPresetMedium())
+    {
+    return 6;
+    }
+  else if (compressionParameter == this->GetNRRDCompressionPresetHigh())
+    {
+    return 9;
+    }
+  return 1;
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLNRRDStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLNRRDStorageNode.h
@@ -78,11 +78,24 @@ protected:
   /// Initialize all the supported write file types
   virtual void InitializeSupportedWriteFileTypes() VTK_OVERRIDE;
 
+  /// Initialize all the supported compression presets
+  virtual void InitializeCompressionPresets() VTK_OVERRIDE;
+
   /// Read data and set it in the referenced node
   virtual int ReadDataInternal(vtkMRMLNode *refNode) VTK_OVERRIDE;
 
   /// Write data from a  referenced node
   virtual int WriteDataInternal(vtkMRMLNode *refNode) VTK_OVERRIDE;
+
+  /// Compression parameter string representing low compression
+  std::string GetNRRDCompressionPresetLow() { return "nrrd_low_compression"; };
+  /// Compression parameter string representing medium compression
+  std::string GetNRRDCompressionPresetMedium() { return "nrrd_medium_compression"; };
+  /// Compression parameter string representing high compression
+  std::string GetNRRDCompressionPresetHigh() { return "nrrd_high_compression"; };
+
+  /// Convert the nrrd compression parameter string to the corresponding integer representation
+  int ConvertNRRDCompressionParameterToInt(std::string parameter);
 
   int CenterImage;
 

--- a/Libs/MRML/Core/vtkMRMLStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.cxx
@@ -46,7 +46,6 @@ vtkMRMLStorageNode::vtkMRMLStorageNode()
   this->URI = NULL;
   this->URIHandler = NULL;
   this->UseCompression = 1;
-  this->CompressionLevel = -1;
   this->ReadState = this->Idle;
   this->WriteState = this->Idle;
   this->URIHandler = NULL;
@@ -186,20 +185,10 @@ void vtkMRMLStorageNode::WriteXML(ostream& of, int nIndent)
   ss << this->UseCompression;
   of << " useCompression=\"" << ss.str() << "\"";
 
-  ss.clear();
-  ss.str(std::string());
-  {
-    of << " compressionLevel=\"";
-    if (this->CompressionLevel == -1)
-      {
-      of << vtkMRMLStorageNode::CompressionLevelDefault;
-      }
-    else
-      {
-      of << this->CompressionLevel;
-      }
-    of << "\"";
-  }
+  if (!this->CompressionParameter.empty())
+    {
+    of << " compressionParameter=\"" << this->XMLAttributeEncodeString(this->CompressionParameter) << "\"";
+    }
 
   if (this->GetDefaultWriteFileExtension() != NULL)
     {
@@ -320,11 +309,9 @@ void vtkMRMLStorageNode::ReadXMLAttributes(const char** atts)
       ss << attValue;
       ss >> this->UseCompression;
       }
-    else if (!strcmp(attName, "compressionLevel"))
+    else if (!strcmp(attName, "compressionParameter"))
       {
-      std::stringstream ss;
-      ss << attValue;
-      ss >> this->CompressionLevel;
+      this->CompressionParameter = attValue;
       }
     else if (!strcmp(attName, "readState"))
       {
@@ -361,6 +348,7 @@ void vtkMRMLStorageNode::Copy(vtkMRMLNode *anode)
     this->AddURI(node->GetNthURI(i));
     }
   this->SetUseCompression(node->UseCompression);
+  this->SetCompressionParameter(node->CompressionParameter);
   this->SetReadState(node->ReadState);
   this->SetWriteState(node->WriteState);
   this->SetDefaultWriteFileExtension(node->GetDefaultWriteFileExtension());
@@ -387,7 +375,11 @@ void vtkMRMLStorageNode::PrintSelf(ostream& os, vtkIndent indent)
     os << indent << "URIListMember: " << this->GetNthURI(i) << "\n";
     }
   os << indent << "UseCompression:   " << this->UseCompression << "\n";
-  os << indent << "CompressionLevel:   " << this->CompressionLevel << "\n";
+  if (!this->CompressionParameter.empty())
+    {
+    os << indent << "CompressionParameter:   " << this->CompressionParameter << "\n";
+    }
+
   os << indent << "ReadState:  " << this->GetReadStateAsString() << "\n";
   os << indent << "WriteState: " << this->GetWriteStateAsString() << "\n";
   os << indent << "SupportedWriteFileTypes: \n";
@@ -1296,4 +1288,93 @@ std::string vtkMRMLStorageNode::GetFileNameWithoutExtension(const char* filePath
     return fileName;
     }
   return fileName.substr(0, fileName.length() - extension.length());
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLStorageNode::InitializeCompressionPresets()
+{
+  this->CompressionPresets.clear();
+}
+
+//------------------------------------------------------------------------------
+int vtkMRMLStorageNode::GetNumberOfCompressionPresets()
+{
+  if (this->CompressionPresets.size() == 0)
+    {
+    this->InitializeCompressionPresets();
+    }
+  return this->CompressionPresets.size();
+}
+
+//------------------------------------------------------------------------------
+std::vector<std::string> vtkMRMLStorageNode::GetCompressionPresetNames()
+{
+  if (this->CompressionPresets.size() == 0)
+    {
+    this->InitializeCompressionPresets();
+    }
+
+  std::vector<std::string> names;
+  std::vector<CompressionPreset>::iterator compressionPresetIt;
+  for (compressionPresetIt = this->CompressionPresets.begin(); compressionPresetIt != this->CompressionPresets.end(); ++compressionPresetIt)
+    {
+    names.push_back(compressionPresetIt->Name);
+    }
+  return names;
+}
+
+//------------------------------------------------------------------------------
+std::string vtkMRMLStorageNode::GetCompressionPreset(const std::string& name)
+{
+  if (this->CompressionPresets.size() == 0)
+    {
+    this->InitializeCompressionPresets();
+    }
+
+  std::vector<CompressionPreset>::iterator compressionPresetIt;
+  for (compressionPresetIt = this->CompressionPresets.begin(); compressionPresetIt != this->CompressionPresets.end(); ++compressionPresetIt)
+    {
+    if (compressionPresetIt->Name == name)
+      {
+      break;
+      }
+    }
+  if (compressionPresetIt == this->CompressionPresets.end())
+    {
+    return "";
+    }
+  return compressionPresetIt->Parameter;
+}
+
+//------------------------------------------------------------------------------
+std::string vtkMRMLStorageNode::GetCompressionPresetName(const std::string& parameter)
+{
+  if (this->CompressionPresets.size() == 0)
+    {
+    this->InitializeCompressionPresets();
+    }
+
+  std::vector<CompressionPreset>::iterator compressionPresetIt;
+  for (compressionPresetIt = this->CompressionPresets.begin(); compressionPresetIt != this->CompressionPresets.end(); ++compressionPresetIt)
+    {
+    if (compressionPresetIt->Parameter == parameter)
+      {
+      break;
+      }
+    }
+  if (compressionPresetIt == this->CompressionPresets.end())
+    {
+    return "";
+    }
+  return compressionPresetIt->Name;
+}
+
+//------------------------------------------------------------------------------
+const std::vector<vtkMRMLStorageNode::CompressionPreset> vtkMRMLStorageNode::GetCompressionPresets()
+{
+  if (this->CompressionPresets.size() == 0)
+    {
+    this->InitializeCompressionPresets();
+    }
+  return this->CompressionPresets;
 }

--- a/Libs/MRML/Core/vtkMRMLStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.h
@@ -92,11 +92,6 @@ public:
   vtkSetMacro(UseCompression, int);
 
   ///
-  /// Compression level for write
-  vtkSetClampMacro(CompressionLevel, int, 0, 9);
-  vtkGetMacro(CompressionLevel, int);
-
-  ///
   /// Location of the remote copy of this file.
   vtkSetStringMacro(URI);
   vtkGetStringMacro(URI);
@@ -124,17 +119,6 @@ public:
     Transferring,
     TransferDone,
     Cancelled
-  };
-
-  ///
-  /// Compression levels
-  enum
-  {
-    CompressionLevelNone = 0,
-    CompressionLevelLow = 1,
-    CompressionLevelMedium = 6,
-    CompressionLevelHigh = 9,
-    CompressionLevelDefault = CompressionLevelLow
   };
 
   /// Get/Set the state of reading
@@ -318,6 +302,30 @@ public:
   /// If filename is not specified then the current FileName will be used.
   std::string GetFileNameWithoutExtension(const char* fileName = NULL);
 
+  /// Compression parameter that is used to save the node
+  vtkSetMacro(CompressionParameter, std::string);
+  vtkGetMacro(CompressionParameter, std::string);
+
+  /// Returns a list of the names of the supported compression presets
+  virtual std::vector<std::string> GetCompressionPresetNames();
+
+  /// Returns a string representing the specified preset
+  virtual std::string GetCompressionPreset(const std::string& name);
+
+  /// Returns the name of the specified preset
+  virtual std::string GetCompressionPresetName(const std::string& preset);
+
+  /// Get the number of compression presets
+  virtual int GetNumberOfCompressionPresets();
+
+  struct CompressionPreset
+  {
+    std::string Name;
+    std::string Parameter;
+  };
+  /// Get a list of all supported compression presets
+  virtual const std::vector<CompressionPreset> GetCompressionPresets();
+
 protected:
   vtkMRMLStorageNode();
   ~vtkMRMLStorageNode();
@@ -349,9 +357,10 @@ protected:
   char *URI;
   vtkURIHandler *URIHandler;
   int UseCompression;
-  int CompressionLevel;
   int ReadState;
   int WriteState;
+  std::string CompressionParameter;
+  std::vector<CompressionPreset> CompressionPresets;
 
   ///
   /// An array of file names, should contain the FileName but may not
@@ -374,6 +383,10 @@ protected:
   /// Initialize all the supported write file types
   /// Subclasses should use this method to initialize SupportedWriteFileTypes.
   virtual void InitializeSupportedWriteFileTypes();
+  ///
+  /// Initialize all of the supported compression presets
+  /// Subclasses should use this method to initialize CompressionPresets
+  virtual void InitializeCompressionPresets();
 
   /// Time when data was last read or written.
   /// This is used by the storable node to know when it needs to save its data

--- a/Libs/vtkAddon/vtkStreamingVolumeCodec.cxx
+++ b/Libs/vtkAddon/vtkStreamingVolumeCodec.cxx
@@ -207,3 +207,51 @@ void vtkStreamingVolumeCodec::PrintSelf(ostream& os, vtkIndent indent)
     os << indent << codecParameterIt->first << "=\"" << codecParameterIt->second << "\"";
     }
 }
+
+//------------------------------------------------------------------------------
+std::vector<std::string> vtkStreamingVolumeCodec::GetParameterPresetNames() const
+{
+  std::vector<std::string> names;
+  std::vector<ParameterPreset>::const_iterator presetIt;
+  for (presetIt = this->ParameterPresets.begin(); presetIt != this->ParameterPresets.end(); ++presetIt)
+    {
+    names.push_back(presetIt->Name);
+    }
+  return names;
+}
+
+//------------------------------------------------------------------------------
+std::string vtkStreamingVolumeCodec::GetParameterPreset(const std::string& name) const
+{
+  std::vector<ParameterPreset>::const_iterator presetIt;
+  for (presetIt = this->ParameterPresets.begin(); presetIt != this->ParameterPresets.end(); ++presetIt)
+    {
+    if (presetIt->Name == name)
+      {
+      break;
+      }
+    }
+  if (presetIt == this->ParameterPresets.end())
+    {
+    return "";
+    }
+  return presetIt->Parameter;
+}
+
+//------------------------------------------------------------------------------
+std::string vtkStreamingVolumeCodec::GetParameterPresetName(const std::string& parameter) const
+{
+  std::vector<ParameterPreset>::const_iterator presetIt;
+  for (presetIt = this->ParameterPresets.begin(); presetIt != this->ParameterPresets.end(); ++presetIt)
+    {
+    if (presetIt->Parameter == parameter)
+      {
+      break;
+      }
+    }
+  if (presetIt == this->ParameterPresets.end())
+    {
+    return "";
+    }
+  return presetIt->Name;
+}

--- a/Libs/vtkAddon/vtkStreamingVolumeCodec.h
+++ b/Libs/vtkAddon/vtkStreamingVolumeCodec.h
@@ -108,8 +108,34 @@ public:
   virtual bool GetParameter(std::string parameterName, std::string& parameterValue);
 
   /// Sets all of the specified parameters in the codec
-  /// \parameters Map containing the parameters and values to be set
+  /// \param parameters Map containing the parameters and values to be set
   virtual void SetParameters(std::map<std::string, std::string> parameters);
+
+  /// Returns a list of the names of the supported parameter presets
+  std::vector<std::string> GetParameterPresetNames() const;
+
+  /// Returns a string representing the specified parameter
+  std::string GetParameterPreset(const std::string& name) const;
+
+  /// Returns the name of the specified parameter
+  std::string GetParameterPresetName(const std::string& preset) const;
+
+  /// Get the number of parameter presets
+  int GetNumberOfParameterPresets() const { return this->ParameterPresets.size(); };
+
+  struct ParameterPreset
+  {
+    std::string Name;
+    std::string Parameter;
+  };
+  // Get a list of all supported parameter presets for the codec
+  vtkGetStdVectorMacro(ParameterPresets, const std::vector<ParameterPreset>);
+
+  /// Set the current parameters based on the specified preset
+  virtual void SetParametersFromPreset(std::string vtkNotUsed(preset)) {};
+
+  /// Get the default preset parameter
+  vtkGetMacro(DefaultParameterPreset, std::string);
 
 protected:
 
@@ -144,9 +170,11 @@ private:
   void operator=(const vtkStreamingVolumeCodec&);
 
 protected:
-  std::vector<std::string>                     AvailiableParameterNames;
-  vtkSmartPointer<vtkStreamingVolumeFrame>     LastDecodedFrame;
-  std::map<std::string, std::string>           Parameters;
+  std::vector<std::string>                  AvailiableParameterNames;
+  vtkSmartPointer<vtkStreamingVolumeFrame>  LastDecodedFrame;
+  std::map<std::string, std::string>        Parameters;
+  std::vector<ParameterPreset>              ParameterPresets;
+  std::string                               DefaultParameterPreset;
 };
 
 #endif


### PR DESCRIPTION
-Adds a framework for specifying different preset levels of compression in vtkMRMLStorageNode
-Changes in vtkStreamingVolumeCodec also allow codecs to specify their own presets
-Replaces previous CompressionLevel int

![image](https://user-images.githubusercontent.com/9222709/47896281-203f6200-de43-11e8-86ba-3fefd21fc138.png)
