### PR TITLE
ENH: Add qSlicerSingletonViewFactory

### DIFF
--- a/Base/QTGUI/CMakeLists.txt
+++ b/Base/QTGUI/CMakeLists.txt
@@ -102,6 +102,9 @@ set(KIT_SRCS
   qSlicerWebWidget_p.h
   qSlicerWidget.cxx
   qSlicerWidget.h
+
+  qSlicerSingletonViewFactory.cxx
+  qSlicerSingletonViewFactory.h
   )
 
 if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT)
@@ -208,6 +211,8 @@ set(KIT_MOC_SRCS
   qSlicerWebWidget.h
   qSlicerWebWidget_p.h
   qSlicerWidget.h
+
+  qSlicerSingletonViewFactory.h
   )
 
 if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT)

--- a/Base/QTGUI/qSlicerSingletonViewFactory.cxx
+++ b/Base/QTGUI/qSlicerSingletonViewFactory.cxx
@@ -1,0 +1,130 @@
+/*==============================================================================
+
+Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+See COPYRIGHT.txt
+or http://www.slicer.org/copyright/copyright.txt for details.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+and was supported through CANARIE's Research Software Program, and Cancer
+Care Ontario.
+
+==============================================================================*/
+
+// QtGUI includes
+#include "qSlicerSingletonViewFactory.h"
+
+#include <QDebug>
+#include <QMap>
+#include <QSharedPointer>
+#include <QWidget>
+
+//-----------------------------------------------------------------------------
+class qSlicerSingletonViewFactoryPrivate
+{
+  Q_DECLARE_PUBLIC(qSlicerSingletonViewFactory);
+public:
+  qSlicerSingletonViewFactoryPrivate(qSlicerSingletonViewFactory& object);
+  virtual ~qSlicerSingletonViewFactoryPrivate();
+
+  virtual void init();
+
+  QSharedPointer<QWidget> Widget;
+  QString TagName;
+
+protected:
+  qSlicerSingletonViewFactory* q_ptr;
+};
+
+//-----------------------------------------------------------------------------
+// qSlicerSingletonViewFactoryPrivate methods
+
+qSlicerSingletonViewFactoryPrivate
+::qSlicerSingletonViewFactoryPrivate(qSlicerSingletonViewFactory& object)
+  : q_ptr(&object)
+  , Widget(NULL)
+{
+}
+
+//-----------------------------------------------------------------------------
+qSlicerSingletonViewFactoryPrivate::~qSlicerSingletonViewFactoryPrivate()
+{
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSingletonViewFactoryPrivate::init()
+{
+}
+
+//-----------------------------------------------------------------------------
+// qSlicerSingletonViewFactory methods
+
+//-----------------------------------------------------------------------------
+qSlicerSingletonViewFactory::qSlicerSingletonViewFactory(QObject* parent)
+  : Superclass(parent)
+  , d_ptr(new qSlicerSingletonViewFactoryPrivate(*this))
+{
+  Q_D(qSlicerSingletonViewFactory);
+  d->init();
+  this->setUseCachedViews(false);
+}
+
+//-----------------------------------------------------------------------------
+qSlicerSingletonViewFactory::~qSlicerSingletonViewFactory()
+{
+}
+
+
+//-----------------------------------------------------------------------------
+QWidget* qSlicerSingletonViewFactory::widget()
+{
+  Q_D(qSlicerSingletonViewFactory);
+  return d->Widget.data();
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSingletonViewFactory::setWidget(QWidget* widget)
+{
+  Q_D(qSlicerSingletonViewFactory);
+  d->Widget = QSharedPointer<QWidget>(widget);
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerSingletonViewFactory::tagName()
+{
+  Q_D(qSlicerSingletonViewFactory);
+  return d->TagName;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSingletonViewFactory::setTagName(QString tagName)
+{
+  Q_D(qSlicerSingletonViewFactory);
+  d->TagName = tagName;
+}
+
+//-----------------------------------------------------------------------------
+QStringList qSlicerSingletonViewFactory::supportedElementNames() const
+{
+  Q_D(const qSlicerSingletonViewFactory);
+  return QStringList() << d->TagName;
+}
+
+//---------------------------------------------------------------------------
+QWidget* qSlicerSingletonViewFactory::createViewFromXML(QDomElement layoutElement)
+{
+  Q_D(qSlicerSingletonViewFactory);
+  if (this->widget()->isVisible())
+    {
+    qCritical() << "qSlicerSingletonViewFactory::createViewFromXML - Widget for view \"" << d->TagName << "\" is already in use within the current layout!";
+    }
+
+  return this->widget();
+}

--- a/Base/QTGUI/qSlicerSingletonViewFactory.h
+++ b/Base/QTGUI/qSlicerSingletonViewFactory.h
@@ -1,0 +1,70 @@
+/*==============================================================================
+
+Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+See COPYRIGHT.txt
+or http://www.slicer.org/copyright/copyright.txt for details.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+and was supported through CANARIE's Research Software Program, and Cancer
+Care Ontario.
+
+==============================================================================*/
+
+#ifndef qSlicerSingletonViewFactory_h
+#define qSlicerSingletonViewFactory_h
+
+// CTK includes
+#include "ctkLayoutViewFactory.h"
+
+// QtGUI includes
+#include "qSlicerBaseQTGUIExport.h"
+
+class ctkDICOMBrowser;
+class qSlicerSingletonViewFactoryPrivate;
+
+/// This class provides an interface for C++ and Python classes to register a singleton view replacement widget.
+/// New view widgets can be registered by registering a new qSlicerSingletonViewFactory, and then setting the widget and tag using setWidget(QWidget*) and
+/// setTagName(QString).
+/// The factory will be responsible for deleting the widget.
+/// This factory contains a single pointer to an instance of the widget, so only one view can be created within a given layout.
+class Q_SLICER_BASE_QTGUI_EXPORT qSlicerSingletonViewFactory : public ctkLayoutViewFactory
+{
+  Q_OBJECT
+public:
+  typedef ctkLayoutViewFactory Superclass;
+  qSlicerSingletonViewFactory(QObject* parent=0);
+  virtual ~qSlicerSingletonViewFactory();
+
+  /// Reimplemented to support custom element names
+  virtual QStringList supportedElementNames()const;
+
+  /// Set the singleton widget instance that will be used to create the view
+  /// The factory will become responsible for deleting the widget
+  Q_INVOKABLE virtual void setWidget(QWidget* widget);
+  /// Get the singleton widget instance that will be used to create the view
+  Q_INVOKABLE virtual QWidget* widget();
+
+  /// Set the XML tag that identifies the view where the widget should be placed
+  Q_INVOKABLE virtual void setTagName(QString tagName);
+  /// Get the XML tag that identifies the view where the widget should be placed
+  Q_INVOKABLE QString tagName();
+
+protected:
+  QScopedPointer<qSlicerSingletonViewFactoryPrivate> d_ptr;
+
+  /// Reimplemented to instantiate desired singleton widget from the element.
+  Q_INVOKABLE virtual QWidget* createViewFromXML(QDomElement layoutElement);
+
+private:
+  Q_DECLARE_PRIVATE(qSlicerSingletonViewFactory)
+};
+
+#endif

--- a/Libs/MRML/Widgets/qMRMLLayoutManager.h
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager.h
@@ -107,7 +107,7 @@ public:
   /// If the registered view factory is a qMRMLLayoutViewFactory, then set
   /// its layoutManager and its mrmlScene.
   /// \sa ctkLayoutFactory::registerViewFactory(), unregisterViewFactory()
-  virtual void registerViewFactory(ctkLayoutViewFactory* viewFactory);
+  Q_INVOKABLE virtual void registerViewFactory(ctkLayoutViewFactory* viewFactory);
 
   /// Return the list of registered MRML view factories.
   /// \sa registeredViewFactories(), registerViewFactory(),


### PR DESCRIPTION
The new view factory can be used by both C++ and Python classes to register any singleton QWidget by calling factory->setWidget(QWidget*) and factory->setTagName(std::string).

Since the widget is a singleton, the factory can only be used to add a single such view to a given layout.

Spun off from https://github.com/Slicer/Slicer/pull/1061