### PR TITLE
BUG: Fix distance encoded projection in Slice view

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.cxx
@@ -262,6 +262,7 @@ void vtkMRMLModelSliceDisplayableManager::vtkInternal
     origin[i] = sliceMatrix->GetElement(i,3);
     }
 
+  vtkMath::Normalize(normal);
   plane->SetNormal(normal);
   plane->SetOrigin(origin);
 }

--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.cxx
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.cxx
@@ -421,6 +421,7 @@ void vtkMRMLSegmentationsDisplayableManager2D::vtkInternal::SetSlicePlaneFromMat
     origin[i] = sliceMatrix->GetElement(i,3);
     }
 
+  vtkMath::Normalize(normal);
   plane->SetNormal(normal);
   plane->SetOrigin(origin);
 }


### PR DESCRIPTION
- Implicit plane function for calculating distance uses SliceXYToRAS, however the distance is scaled in the Z direction
- Fixed by normalizing the plane normal used for distance encoded projection