### PR TITLE
BUG: Fix MRMLNodeComboBox_Segmentation is not found in Segment Editor module

### DIFF
--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
@@ -472,7 +472,7 @@ void qSlicerSegmentationsModuleWidget::onEditSelectedSegment()
     return;
     }
   // Get segmentation selector combobox and set segmentation
-  qMRMLNodeComboBox* nodeSelector = moduleWidget->findChild<qMRMLNodeComboBox*>("MRMLNodeComboBox_Segmentation");
+  qMRMLNodeComboBox* nodeSelector = moduleWidget->findChild<qMRMLNodeComboBox*>("SegmentationNodeComboBox");
   if (!nodeSelector)
     {
     qCritical() << Q_FUNC_INFO << ": MRMLNodeComboBox_Segmentation is not found in Segment Editor module";


### PR DESCRIPTION
When using the "Edit selected" button in Segmentations to switch to the Segment Editor, the Segmentations module widget attempts to find the node selector, however the name is incorrect.
Name was: MRMLNodeComboBox_Segmentation
Should be: SegmentationNodeComboBox

Fixed by looking for the correct name in Segmentations.