### PR TITLE
ENH: Improve loading speed when importing segmentation from labelmap

### DIFF
--- a/Libs/MRML/Core/vtkMRMLNode.h
+++ b/Libs/MRML/Core/vtkMRMLNode.h
@@ -953,4 +953,27 @@ private:
   std::map<int, int> CustomModifiedEventPending; // event id, pending value (number of events grouped together)
 };
 
+/// \brief Simple class that calls StartModify on instantiation and EndModify on destruction.
+class VTK_MRML_EXPORT MRMLNodeModify
+{
+public:
+  vtkWeakPointer<vtkMRMLNode> Node;
+  int WasModifying;
+  MRMLNodeModify(vtkMRMLNode* node)
+  {
+    this->Node = node;
+    if (this->Node)
+      {
+      this->WasModifying = this->Node->StartModify();
+      }
+  };
+  ~MRMLNodeModify()
+  {
+    if (this->Node)
+      {
+      this->Node->EndModify(this->WasModifying);
+      }
+  }
+};
+
 #endif

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -1282,7 +1282,7 @@ bool vtkSlicerSegmentationsModuleLogic::ImportLabelmapToSegmentationNode(vtkMRML
   //   run the thresholding in single threaded mode to avoid data corruption observed on mac release builds
   //threshold->SetNumberOfThreads(1);
 
-  int segmentationNodeWasModified = segmentationNode->StartModify();
+  MRMLNodeModify currentSegmentationNodeModify(segmentationNode);
   for (int labelIndex = 0; labelIndex < labelValues->GetNumberOfValues(); ++labelIndex)
     {
     int label = labelValues->GetValue(labelIndex);
@@ -1352,8 +1352,6 @@ bool vtkSlicerSegmentationsModuleLogic::ImportLabelmapToSegmentationNode(vtkMRML
       }
     } // for each label
 
-  segmentationNode->EndModify(segmentationNodeWasModified);
-
   return true;
 }
 
@@ -1384,7 +1382,7 @@ bool vtkSlicerSegmentationsModuleLogic::ImportLabelmapToSegmentationNode(vtkOrie
   vtkNew<vtkIntArray> labelValues;
   vtkSlicerSegmentationsModuleLogic::GetAllLabelValues(labelValues.GetPointer(), labelmapImage);
 
-  int segmentationNodeWasModified = segmentationNode->StartModify();
+  MRMLNodeModify currentSegmentationNodeModify(segmentationNode);
 
   vtkSmartPointer<vtkImageThreshold> threshold = vtkSmartPointer<vtkImageThreshold>::New();
   threshold->SetInputData(labelmapImage);
@@ -1436,8 +1434,6 @@ bool vtkSlicerSegmentationsModuleLogic::ImportLabelmapToSegmentationNode(vtkOrie
       return false;
       }
     } // for each label
-
-  segmentationNode->EndModify(segmentationNodeWasModified);
 
   return true;
 }
@@ -1526,7 +1522,7 @@ bool vtkSlicerSegmentationsModuleLogic::ImportLabelmapToSegmentationNode(
   threshold->ReplaceOutOn();
   threshold->SetOutputScalarType(labelmapImage->GetScalarType());
 
-  int segmentationNodeWasModified = segmentationNode->StartModify();
+  MRMLNodeModify currentSegmentationNodeModify(segmentationNode);
   for (int segmentIndex = 0; segmentIndex < updatedSegmentIDs->GetNumberOfValues(); ++segmentIndex)
   {
     std::string segmentId = updatedSegmentIDs->GetValue(segmentIndex);
@@ -1560,8 +1556,6 @@ bool vtkSlicerSegmentationsModuleLogic::ImportLabelmapToSegmentationNode(
 
   } // for each label
 
-  segmentationNode->EndModify(segmentationNodeWasModified);
-
   return true;
 }
 
@@ -1569,6 +1563,8 @@ bool vtkSlicerSegmentationsModuleLogic::ImportLabelmapToSegmentationNode(
 bool vtkSlicerSegmentationsModuleLogic::ImportLabelmapToSegmentationNodeWithTerminology(vtkMRMLLabelMapVolumeNode* labelmapNode,
   vtkMRMLSegmentationNode* segmentationNode, std::string terminologyContextName, std::string insertBeforeSegmentId/*=""*/)
 {
+  MRMLNodeModify currentSegmentationNodeModify(segmentationNode);
+
   // Import labelmap to segmentation
   if (! vtkSlicerSegmentationsModuleLogic::ImportLabelmapToSegmentationNode(
         labelmapNode, segmentationNode, insertBeforeSegmentId ) )
@@ -2007,6 +2003,8 @@ bool vtkSlicerSegmentationsModuleLogic::SetTerminologyToSegmentationFromLabelmap
     terminologyContextName, categories[firstNonEmptyCategoryIndex], typesInFirstCategory[0], firstType );
   firstTerminologyEntry->GetTypeObject()->Copy(firstType);
   std::string firstTerminologyString = this->TerminologiesLogic->SerializeTerminologyEntry(firstTerminologyEntry);
+
+  MRMLNodeModify currentSegmentationNodeModify(segmentationNode);
 
   // Assign terminology entry to each segment in the segmentation
   std::vector<std::string> segmentIDs;

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsModel.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsModel.cxx
@@ -558,10 +558,9 @@ void qMRMLSegmentsModel::updateItemDataFromSegment(QStandardItem* item, QString 
 void qMRMLSegmentsModel::updateSegmentFromItem(QString segmentID, QStandardItem* item)
 {
   Q_D(qMRMLSegmentsModel);
-  //int wasModifying = d->SegmentationNode->StartModify(); //TODO: Add feature to item if there are performance issues
-  // Can't call StartModfiy/EndModify currently, since SegmentID will be lost (likely because the calldata is a std::string::c_str).
+  //MRMLNodeModify segmentationNodeModify(d->SegmentationNode);//TODO: Add feature to item if there are performance issues
+  // Calling StartModfiy/EndModify will cause the calldata to be erased, cauding the whole table to be updated
   this->updateSegmentFromItemData(segmentID, item);
-  //d->SegmentationNode->EndModify(wasModifying);
 }
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
@@ -914,7 +914,7 @@ void qMRMLSegmentsTableView::showOnlySelectedSegments()
     }
 
   // Hide all segments except the selected ones
-  int disabledModify = displayNode->StartModify();
+  MRMLNodeModify displayNodeModify(displayNode);
   QStringList displayedSegmentIDs = this->displayedSegmentIDs();
   foreach (QString segmentId, displayedSegmentIDs)
     {
@@ -926,7 +926,6 @@ void qMRMLSegmentsTableView::showOnlySelectedSegments()
 
     displayNode->SetSegmentVisibility(segmentId.toLatin1().constData(), visible);
     }
-  displayNode->EndModify(disabledModify);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Before this change, SetTerminologyToSegmentationFromLabelmapNode would call vtkSegment::SetTag, invoking a vtkSegment::SegmentModified event on the Segmentation node for each segment.
This event was not handled with a StartModify/EndModify, so it caused a major slowdown.

Improvements:
* Added new class "MRMLNodeModify" to vtkMRMLNode.h that calls StartModify on construction and EndModify on destruction
* Added MRMLNodeModify(segmentationNode) to vtkSlicerSegmentationsModuleLogic to prevent unnecessary SegmentModified events