### PR TITLE
BUG: Fix segment selection change during undo

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsModel.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsModel.h
@@ -66,6 +66,7 @@ public:
   enum SegmentTableItemDataRole
   {
     SegmentIDRole = Qt::UserRole + 1,
+    IndexRole,
     VisibilityRole,
     StatusRole,
   };

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSortFilterSegmentsProxyModel.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSortFilterSegmentsProxyModel.cxx
@@ -74,12 +74,6 @@ qMRMLSortFilterSegmentsProxyModel::qMRMLSortFilterSegmentsProxyModel(QObject *vp
  : QSortFilterProxyModel(vparent)
  , d_ptr(new qMRMLSortFilterSegmentsProxyModelPrivate)
 {
-  // For speed issue, we might want to disable the dynamic sorting however
-  // when having source models using QStandardItemModel, drag&drop is handled
-  // in 2 steps, first a new row is created (which automatically calls
-  // filterAcceptsRow() that returns false) and then set the row with the
-  // correct values (which doesn't call filterAcceptsRow() on the up to date
-  // value unless DynamicSortFilter is true).
   this->setDynamicSortFilter(true);
 }
 


### PR DESCRIPTION
Calling takeRow() and insertRow() caused an intermediate state where
the selected segment was removed from the table and caused the
selection in the table to change.

To fix this the order is only updated when it is required, and signals
from the model are now blocked while the order of the segments is being
updated, and the reorderItems method now emits layoutAboutToBeChanged
and layoutChanged to ensure that the table is up to date.