### PR TITLE
COMP: Update minimum required CMAKE_OSX_DEPLOYMENT_TARGET to 10.12

### DIFF
--- a/CMake/SlicerDashboardScript.TEMPLATE.cmake
+++ b/CMake/SlicerDashboardScript.TEMPLATE.cmake
@@ -34,7 +34,7 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.10.0")
+dashboard_set(QT_VERSION          "5.12.7")
 dashboard_set(Qt5_DIR             "${DASHBOARDS_DIR}/Support/Qt${QT_VERSION}/${QT_VERSION}/gcc_64/lib/cmake/Qt5")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>

--- a/CMake/SlicerDashboardScript.TEMPLATE.cmake
+++ b/CMake/SlicerDashboardScript.TEMPLATE.cmake
@@ -19,7 +19,7 @@ dashboard_set(Slicer_RELEASE_TYPE   "Experimental")   # (E)xperimental, (P)revie
 dashboard_set(WITH_PACKAGES         FALSE)            # Enable to generate packages
 dashboard_set(SVN_REVISION          "")               # Specify a revision for Stable release
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 dashboard_set(COMPILER              "g++-X.Y.Z")      # Used only to set the build name

--- a/CMake/SlicerInitializeOSXVariables.cmake
+++ b/CMake/SlicerInitializeOSXVariables.cmake
@@ -64,7 +64,7 @@ if(APPLE)
   endif()
 
   # Starting with 10.9, libc++ replaces libstdc++ as the default runtime.
-  set(required_deployment_target "10.11")
+  set(required_deployment_target "10.12")
 
   if(CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS ${required_deployment_target})
     message(FATAL_ERROR "CMAKE_OSX_DEPLOYMENT_TARGET ${CMAKE_OSX_DEPLOYMENT_TARGET} must be ${required_deployment_target} or greater.")

--- a/Extensions/CMake/SlicerExtensionsDashboardScript.TEMPLATE.cmake
+++ b/Extensions/CMake/SlicerExtensionsDashboardScript.TEMPLATE.cmake
@@ -29,7 +29,7 @@ dashboard_set(CTEST_BUILD_FLAGS     "")               # Use multiple CPU cores t
 dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
 dashboard_set(EXTENSIONS_BUILDSYSTEM_TESTING FALSE)   # If enabled, build <Slicer_SOURCE_DIR>/Extensions/*.s4ext
 
-dashboard_set(QT_VERSION            "5.10.0")         # Used only to set the build name
+dashboard_set(QT_VERSION            "5.12.7")         # Used only to set the build name
 
 #   Slicer_SOURCE_DIR: <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Slicer_DIR       : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build

--- a/Extensions/CMake/SlicerExtensionsDashboardScript.TEMPLATE.cmake
+++ b/Extensions/CMake/SlicerExtensionsDashboardScript.TEMPLATE.cmake
@@ -18,7 +18,7 @@ dashboard_set(SCRIPT_MODE           "Experimental")   # Experimental, Continuous
 dashboard_set(Slicer_RELEASE_TYPE   "Experimental")   # (E)xperimental, (P)review or (S)table
 dashboard_set(EXTENSIONS_INDEX_BRANCH "master")       # "master", X.Y, ...
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 dashboard_set(COMPILER              "g++-X.Y.Z")      # Used only to set the build name


### PR DESCRIPTION
This change is motivated by:

* Deployment target >= 10.12 is the one officially supported by Qt 5.12.
  See https://doc-snapshots.qt.io/qt5-5.12/supported-platforms.html

xref https://github.com/Slicer/DashboardScripts/pull/24.
xref https://github.com/Slicer/DashboardScripts/pull/27