### PR TITLE
BUG: Fix logic issue in qMRMLSegmentsModel

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsModel.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsModel.cxx
@@ -721,9 +721,9 @@ void qMRMLSegmentsModel::onEvent(
 
   // Get segment ID for segmentation node events
   QString segmentID;
-  if (callData && (vtkSegmentation::SegmentAdded
-                || vtkSegmentation::SegmentRemoved
-                || vtkSegmentation::SegmentModified))
+  if (callData && (event == vtkSegmentation::SegmentAdded
+                || event == vtkSegmentation::SegmentRemoved
+                || event == vtkSegmentation::SegmentModified))
     {
     const char* segmentIDPtr = reinterpret_cast<const char*>(callData);
     if (segmentIDPtr)


### PR DESCRIPTION
Within qMRMLSegmentsModel::onEvent(), the events:
* vtkSegmentation::SegmentAdded
* vtkSegmentation::SegmentRemoved
* vtkSegmentation::SegmentModified
should have been compared against the event argument.

Discussion here:
https://github.com/Slicer/Slicer/commit/9d730b3ef2987b69d12689a084c5a0b420a6dacf#r34651776