### PR TITLE
BUG: Fix segment binary labelmap outline thickness

### DIFF
--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.cxx
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.cxx
@@ -835,16 +835,6 @@ void vtkMRMLSegmentationsDisplayableManager2D::vtkInternal::UpdateDisplayNodePip
       pipeline->ImageOutlineActor->SetVisibility(false);
       pipeline->ImageFillActor->SetVisibility(false);
 
-      // Set outline properties and turn it off if not shown
-      if (segmentOutlineVisible)
-        {
-        pipeline->LabelOutline->SetOutline(genericDisplayNode->GetSliceIntersectionThickness());
-        }
-      else
-        {
-        pipeline->LabelOutline->SetInputConnection(nullptr);
-        }
-
       if ((!segmentOutlineVisible && !segmentFillVisible) || (!polyData || polyData->GetNumberOfPoints() == 0))
         {
         pipeline->PolyDataOutlineActor->SetVisibility(false);
@@ -967,6 +957,16 @@ void vtkMRMLSegmentationsDisplayableManager2D::vtkInternal::UpdateDisplayNodePip
       if (!outlineVisible && !fillVisible)
         {
         continue;
+        }
+
+      // Set outline properties and turn it off if not shown
+      if (outlineVisible)
+        {
+        pipeline->LabelOutline->SetOutline(genericDisplayNode->GetSliceIntersectionThickness());
+        }
+      else
+        {
+        pipeline->LabelOutline->SetInputConnection(nullptr);
         }
 
       // Set the range of the scalars in the image data from the ScalarRange field if it exists


### PR DESCRIPTION
The code for setting the labelmap outline thickness was placed in the polydata section of UpdateSegmentPipelines.
Moved relevant code to the correct location.