### PR TITLE
BUG: Fix bugs in segment editor paint effect

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect.cxx
@@ -439,6 +439,10 @@ void qSlicerSegmentEditorPaintEffectPrivate::paintApply(qMRMLWidget* viewWidget)
       updateExtentList << updateExtent[i];
       }
     }
+
+  // Rendering the feedback actor with no points will result in an error message that will clutter the log.
+  // "No input data"
+  this->clearBrushPipelines();
   this->PaintCoordinates_World->Reset();
 
   // Notify editor about changes


### PR DESCRIPTION
* "No input data" message when using paint effect
  When rendering the brush feedback actor with no points in the pipeline, there could be a large number of "No input data" error messages that would pollute the log.
  The pipeline is now cleared before the points are removed to prevent this message from occurring.

* Expansion of segment extent beyond reference geometry
  Normally when editing a segment, the labelmap is padded to contain the modifier extent, and then clipped to the effective extent.
  If vtkOrientedImageDataResample::MergeImage() indicated that the segment was not modified, then the segment would not be reduced to its effective extent, even if it had been padded.
  This is fixed by reducing the segment to its effective extent regardless of whether or not MergeImage indicates that the segment was modified.