### PR TITLE
ENH: Center paint effect cylinder brush at mouse location

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect_p.h
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect_p.h
@@ -106,9 +106,17 @@ protected:
   /// Paint labelmap
   void paintApply(qMRMLWidget* viewWidget);
 
-  /// Paint one pixel to coordinate
-  void paintPixel(qMRMLWidget* viewWidget, double brushPosition_World[3]);
-  void paintPixels(qMRMLWidget* viewWidget, vtkPoints* pixelPositions);
+  /// Paint brushes to the modifier labelmap
+  void paintBrushes(vtkOrientedImageData* modifierLabelmap, qMRMLWidget* viewWidget, vtkPoints* pixelPositions_World, int extent[6]=nullptr);
+
+  /// Paint one pixel at coordinate
+  void paintPixel(vtkOrientedImageData* modifierLabelmap, qMRMLWidget* viewWidget, double pixelPosition_World[3]);
+
+  /// Paint pixels at the coordinates
+  void paintPixels(vtkOrientedImageData* modifierLabelmap, vtkPoints* pixelPositions_World, int extent[6]=nullptr);
+
+  /// Transform points from World to IJK
+  void transformPointsFromWorldToIJK(vtkOrientedImageData* image, vtkMRMLSegmentationNode* segmentationNode, vtkPoints* inputPoints, vtkPoints* outputPoints);
 
   /// Scale brush diameter and save it in parameter node
   void scaleDiameter(double scaleFactor);


### PR DESCRIPTION
Previously the center of the vtkCylinderSource was offset from the mouse position.
This also caused issues with painting such as not being able to paint a single pixel in certain views, and not being able to paint at all when using a small diameter brush.
Both of these issues were fixed by centering the the brush model at the mouse location.

This commit also implements the BrushPixelMode, although it is not currently accessible to users.