### PR TITLE
BUG: Fix keep largest and remove smallest islands in island effect

### DIFF
--- a/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.cxx
+++ b/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.cxx
@@ -316,7 +316,7 @@ bool vtkBinaryLabelmapToClosedSurfaceConversionRule::CreateClosedSurface(vtkOrie
     {
     vtkDebugMacro("Convert: No polygons can be created, probably all voxels are empty");
     convertedSegment = nullptr;
-    closedSurfacePolyData->Reset();
+    closedSurfacePolyData->Initialize();
     }
 
   if (!convertedSegment)

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorIslandsEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorIslandsEffect.py
@@ -149,57 +149,77 @@ class SegmentEditorIslandsEffect(AbstractScriptedSegmentEditorEffect):
     selectedSegmentLabelmap.GetImageToWorldMatrix(selectedSegmentLabelmapImageToWorldMatrix)
     islandImage.SetImageToWorldMatrix(selectedSegmentLabelmapImageToWorldMatrix)
 
-    if split and (maxNumberOfSegments != 1):
+    islandCount = islandMath.GetNumberOfIslands()
+    islandOrigCount = islandMath.GetOriginalNumberOfIslands()
+    ignoredIslands = islandOrigCount - islandCount
+    logging.info( "%d islands created (%d ignored)" % (islandCount, ignoredIslands) )
 
-      islandCount = islandMath.GetNumberOfIslands()
-      islandOrigCount = islandMath.GetOriginalNumberOfIslands()
-      ignoredIslands = islandOrigCount - islandCount
-      logging.info( "%d islands created (%d ignored)" % (islandCount, ignoredIslands) )
+    baseSegmentName = "Label"
+    selectedSegmentID = self.scriptedEffect.parameterSetNode().GetSelectedSegmentID()
+    segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
+    segmentation = segmentationNode.GetSegmentation()
+    selectedSegment = segmentation.GetSegment(selectedSegmentID)
+    selectedSegmentName = selectedSegment.GetName()
+    if selectedSegmentName is not None and selectedSegmentName != "":
+      baseSegmentName = selectedSegmentName
 
-      baseSegmentName = "Label"
-      selectedSegmentID = self.scriptedEffect.parameterSetNode().GetSelectedSegmentID()
-      segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
-      segmentation = segmentationNode.GetSegmentation()
-      selectedSegment = segmentation.GetSegment(selectedSegmentID)
-      selectedSegmentName = selectedSegment.GetName()
-      if selectedSegmentName is not None and selectedSegmentName != "":
-        baseSegmentName = selectedSegmentName
+    labelValues = vtk.vtkIntArray();
+    slicer.vtkSlicerSegmentationsModuleLogic.GetAllLabelValues(labelValues, islandImage);
 
-      labelValues = vtk.vtkIntArray();
-      slicer.vtkSlicerSegmentationsModuleLogic.GetAllLabelValues(labelValues, islandImage);
+    # Erase segment from in original labelmap.
+    # Individuall islands will be added back later.
+    threshold = vtk.vtkImageThreshold()
+    threshold.SetInputData(selectedSegmentLabelmap)
+    threshold.ThresholdBetween(0, 0)
+    threshold.SetInValue(0)
+    threshold.SetOutValue(0)
+    threshold.Update()
+    emptyLabelmap = slicer.vtkOrientedImageData()
+    emptyLabelmap.ShallowCopy(threshold.GetOutput())
+    emptyLabelmap.CopyDirections(selectedSegmentLabelmap)
+    self.scriptedEffect.modifySegmentByLabelmap(segmentationNode, selectedSegmentID, emptyLabelmap,
+      slicer.qSlicerSegmentEditorAbstractEffect.ModificationModeSet)
 
-      for i in range(labelValues.GetNumberOfTuples()):
-        labelValue = int(labelValues.GetTuple1(i))
-        if i == 0:
-          segment = selectedSegment
-          segmentID = selectedSegmentID
-        else:
-          segment = slicer.vtkSegment()
-          name = baseSegmentName + "_" + str(i+1)
-          segment.SetName(name)
-          segment.AddRepresentation(slicer.vtkSegmentationConverter.GetSegmentationBinaryLabelmapRepresentationName(),
-            selectedSegment.GetRepresentation(slicer.vtkSegmentationConverter.GetSegmentationBinaryLabelmapRepresentationName()));
-          segmentation.AddSegment(segment)
-          segmentID = segmentation.GetSegmentIdBySegment(segment)
-          segment.SetLabelValue(segmentation.GetUniqueLabelValueForSharedLabelmap(selectedSegmentID))
+    for i in range(labelValues.GetNumberOfTuples()):
+      if (maxNumberOfSegments > 0 and i >= maxNumberOfSegments):
+        # We only care about the segments up to maxNumberOfSegments.
+        # If we do not want to split segments, we only care about the first.
+        break
 
-        threshold = vtk.vtkImageThreshold()
-        threshold.SetInputData(islandMath.GetOutput())
-        threshold.ThresholdBetween(labelValue, labelValue)
-        threshold.SetInValue(1)
-        threshold.SetOutValue(0)
-        threshold.Update()
+      labelValue = int(labelValues.GetTuple1(i))
+      segment = selectedSegment
+      segmentID = selectedSegmentID
+      if i != 0 and split:
+        segment = slicer.vtkSegment()
+        name = baseSegmentName + "_" + str(i+1)
+        segment.SetName(name)
+        segment.AddRepresentation(slicer.vtkSegmentationConverter.GetSegmentationBinaryLabelmapRepresentationName(),
+          selectedSegment.GetRepresentation(slicer.vtkSegmentationConverter.GetSegmentationBinaryLabelmapRepresentationName()));
+        segmentation.AddSegment(segment)
+        segmentID = segmentation.GetSegmentIdBySegment(segment)
+        segment.SetLabelValue(segmentation.GetUniqueLabelValueForSharedLabelmap(selectedSegmentID))
 
-        # Create oriented image data from output
-        modifierImage = slicer.vtkOrientedImageData()
-        modifierImage.DeepCopy(threshold.GetOutput())
-        selectedSegmentLabelmapImageToWorldMatrix = vtk.vtkMatrix4x4()
-        selectedSegmentLabelmap.GetImageToWorldMatrix(selectedSegmentLabelmapImageToWorldMatrix)
-        modifierImage.SetGeometryFromImageToWorldMatrix(selectedSegmentLabelmapImageToWorldMatrix)
-        # We could use a single slicer.vtkSlicerSegmentationsModuleLogic.ImportLabelmapToSegmentationNode
-        # method call to import all the resulting segments at once but that would put all the imported segments
-        # in a new layer. By using modifySegmentByLabelmap, the number of layers will not increase.
-        self.scriptedEffect.modifySegmentByLabelmap(segmentationNode, segmentID, modifierImage, slicer.qSlicerSegmentEditorAbstractEffect.ModificationModeSet)
+      threshold = vtk.vtkImageThreshold()
+      threshold.SetInputData(islandMath.GetOutput())
+      threshold.ThresholdBetween(labelValue, labelValue)
+      threshold.SetInValue(1)
+      threshold.SetOutValue(0)
+      threshold.Update()
+
+      modificationMode = slicer.qSlicerSegmentEditorAbstractEffect.ModificationModeAdd
+      if i == 0:
+        modificationMode = slicer.qSlicerSegmentEditorAbstractEffect.ModificationModeSet
+
+      # Create oriented image data from output
+      modifierImage = slicer.vtkOrientedImageData()
+      modifierImage.DeepCopy(threshold.GetOutput())
+      selectedSegmentLabelmapImageToWorldMatrix = vtk.vtkMatrix4x4()
+      selectedSegmentLabelmap.GetImageToWorldMatrix(selectedSegmentLabelmapImageToWorldMatrix)
+      modifierImage.SetGeometryFromImageToWorldMatrix(selectedSegmentLabelmapImageToWorldMatrix)
+      # We could use a single slicer.vtkSlicerSegmentationsModuleLogic.ImportLabelmapToSegmentationNode
+      # method call to import all the resulting segments at once but that would put all the imported segments
+      # in a new layer. By using modifySegmentByLabelmap, the number of layers will not increase.
+      self.scriptedEffect.modifySegmentByLabelmap(segmentationNode, segmentID, modifierImage, modificationMode)
 
     qt.QApplication.restoreOverrideCursor()
 
@@ -269,7 +289,6 @@ class SegmentEditorIslandsEffect(AbstractScriptedSegmentEditorEffect):
     pixelValue = inputLabelImage.GetScalarComponentAsFloat(ijk[0], ijk[1], ijk[2], 0)
 
     try:
-
       floodFillingFilter = vtk.vtkImageThresholdConnectivity()
       floodFillingFilter.SetInputData(inputLabelImage)
       seedPoints = vtk.vtkPoints()


### PR DESCRIPTION
The splitSegments arguments maxNumberOfSegments and split did not have any effect, causing the KEEP_LARGEST_ISLAND and REMOVE_SMALL_ISLANDS options to not be functional.
This commit fixes the splitSegments function to use the arguments, and also adds an island effect test section to SegmentationsModuleTest2.