### PR TITLE
BUG: Block MasterRepresentationModified in CollapseBinaryLabelmaps

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
@@ -896,6 +896,11 @@ void vtkMRMLSegmentationNode::GetBinaryLabelmapRepresentation(const std::string 
 
   vtkOrientedImageData* binaryLabelmap = vtkOrientedImageData::SafeDownCast(
     segment->GetRepresentation(vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName()));
+  if (!binaryLabelmap)
+    {
+    vtkErrorMacro("GetBinaryLabelmapRepresentation: No binary labelmap representation in segment");
+    return;
+    }
 
   vtkNew<vtkImageThreshold> threshold;
   threshold->SetInputData(binaryLabelmap);
@@ -961,7 +966,13 @@ void vtkMRMLSegmentationNode::GetClosedSurfaceRepresentation(const std::string s
     vtkErrorMacro("GetClosedSurfaceRepresentation: Invalid segment");
     return;
     }
-  outputClosedSurface->DeepCopy(segment->GetRepresentation(vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName()));
+  vtkDataObject* closedSurface = segment->GetRepresentation(vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName());
+  if (!closedSurface)
+    {
+    vtkErrorMacro("GetClosedSurfaceRepresentation: No closed surface representation in segment")
+    return;
+    }
+  outputClosedSurface->DeepCopy(closedSurface);
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/vtkSegmentationCore/vtkSegmentation.cxx
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.cxx
@@ -2417,6 +2417,9 @@ void vtkSegmentation::CollapseBinaryLabelmaps(bool forceToSingleLayer/*=false*/)
       }
     }
 
+  // Although the labelmaps have been collapsed, the individual segment contents should not have been modified.
+  // Don't invoke a MasterRepresentation modified event, since that would invalidate the derived representations.
+  bool wasMasterRepresentationModifiedEnabled = this->SetMasterRepresentationModifiedEnabled(false);
   for (LayerType newLayer : newLayers)
     {
     for (std::string segmentId : newLayer.second)
@@ -2427,4 +2430,5 @@ void vtkSegmentation::CollapseBinaryLabelmaps(bool forceToSingleLayer/*=false*/)
       }
     newLayer.first->Modified();
     }
+  this->SetMasterRepresentationModifiedEnabled(wasMasterRepresentationModifiedEnabled);
 }


### PR DESCRIPTION
Fixes failing SegmentStatistics test.
If CollapseBinaryLabelmaps is called at the vtkSegmentation level, it can invalidate non master representations, even though the actual content of the segment has not been modified.
This commit prevents MasterRepresentationModified from being called when forceToSingleLayer is false.